### PR TITLE
Add usages for 0.3.5-alpha

### DIFF
--- a/docs/0.3.5-alpha/stdlib/doc/array.md
+++ b/docs/0.3.5-alpha/stdlib/doc/array.md
@@ -1,7 +1,7 @@
 ## `array_first_index`
 
 ```ab
-import { array_first_index } from "std/array.ab"
+import { array_first_index } from "std/array"
 ```
 
 ```ab
@@ -19,7 +19,7 @@ You can check the original tests for code examples:
 ## `array_search`
 
 ```ab
-import { array_search } from "std/array.ab"
+import { array_search } from "std/array"
 ```
 
 ```ab
@@ -36,7 +36,7 @@ You can check the original tests for code examples:
 ## `includes`
 
 ```ab
-import { includes } from "std/array.ab"
+import { includes } from "std/array"
 ```
 
 ```ab

--- a/docs/0.3.5-alpha/stdlib/doc/array.md
+++ b/docs/0.3.5-alpha/stdlib/doc/array.md
@@ -1,26 +1,57 @@
 ## `array_first_index`
+
+```ab
+import { array_first_index } from "std/array.ab"
+```
+
 ```ab
 pub fun array_first_index(array, value): Num 
 ```
 
-Returns index of the first value found in the specified array.
+Returns index of the first value found in the specified array
+If the value is not found, the function returns -1
 
-If the value is not found, the function returns -1.
 
+
+You can check the original tests for code examples:
+* [array_first_index.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/array_first_index.ab)
 
 ## `array_search`
+
+```ab
+import { array_search } from "std/array.ab"
+```
+
 ```ab
 pub fun array_search(array, value): [Num] 
 ```
 
-Searches for a value in an array and returns an array with the index of the various items.
+Search the value in array and return an array with the index of the various items
 
+
+
+You can check the original tests for code examples:
+* [array_search.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/array_search.ab)
 
 ## `includes`
+
+```ab
+import { includes } from "std/array.ab"
+```
+
 ```ab
 pub fun includes(array, value) 
 ```
 
-Checks if a value is in the array.
+Check if the value is in the array
 
+
+
+You can check the original tests for code examples:
+* [includes_empty_num_array.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/includes_empty_num_array.ab)
+* [includes_empty_text_array.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/includes_empty_text_array.ab)
+* [includes_exact_match.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/includes_exact_match.ab)
+* [includes_partial_match_with_expanded_element.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/includes_partial_match_with_expanded_element.ab)
+* [includes_prefix_match.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/includes_prefix_match.ab)
+* [includes_text_array.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/includes_text_array.ab)
 

--- a/docs/0.3.5-alpha/stdlib/doc/date.md
+++ b/docs/0.3.5-alpha/stdlib/doc/date.md
@@ -1,7 +1,7 @@
 ## `date_posix`
 
 ```ab
-import { date_posix } from "std/date.ab"
+import { date_posix } from "std/date"
 ```
 
 ```ab
@@ -78,7 +78,7 @@ You can check the original tests for code examples:
 ## `now`
 
 ```ab
-import { now } from "std/date.ab"
+import { now } from "std/date"
 ```
 
 ```ab
@@ -95,7 +95,7 @@ You can check the original tests for code examples:
 ## `date_add`
 
 ```ab
-import { date_add } from "std/date.ab"
+import { date_add } from "std/date"
 ```
 
 ```ab
@@ -136,7 +136,7 @@ If date_b is not provided, current date will be used
 ## `date_compare`
 
 ```ab
-import { date_compare } from "std/date.ab"
+import { date_compare } from "std/date"
 ```
 
 ```ab

--- a/docs/0.3.5-alpha/stdlib/doc/date.md
+++ b/docs/0.3.5-alpha/stdlib/doc/date.md
@@ -1,60 +1,19 @@
-## `date_add`
-```ab
-pub fun date_add(add: Text, date: Text = "", utc: Bool = false): Text ? 
-```
-
-### EXPERIMENTAL
-
-Adds a value to a date.
-
-If no date is specified, the current date is used.
-
-Example : `date_add("+3 days")`
-
-You can use (+/-):
-
-- years
-- months
-- days
-- hours
-- minutes
-- seconds
-
-
-## `date_compare`
-```ab
-pub fun date_compare(date_a: Text, date_b: Text = "", utc: Bool = false): Num ? 
-```
-
-### EXPERIMENTAL
-Compares two dates.
-
-Returns 1 if date_a is after date_b.
-
-Returns 0 if date_a and date_b is the same.
-
-Returns -1 if date_b is after date_a.
-
-If date_b is not provided, current date will be used.
-
-
 ## `date_posix`
+
+```ab
+import { date_posix } from "std/date.ab"
+```
+
 ```ab
 pub fun date_posix(format: Text = "", date: Text = "", utc: Bool = false): Text ? 
 ```
 
-### EXPERIMENTAL
-
-Formats a date with a special format.
-
-If no date is specified, the current date is used.
-
-If no format is specified, "%FT%T%Z" format is used.
-
-For more info about format type "man date" on your shell or go to <https://www.gnu.org/software/coreutils/date>.
-
+EXPERIMENTAL
+Format a date with a special format
+If no date is specified, the current date is used
+If no format is specified, "%FT%T%Z" format is used
+For more info about format type "man date" on your shell or go to https://www.gnu.org/software/coreutils/date
 Format :
-```
 %%     a literal %
 %a     locale's abbreviated weekday name (e.g., Sun)
 %A     locale's full weekday name (e.g., Sunday)
@@ -101,25 +60,89 @@ Format :
 %::z   +hh:mm:ss numeric time zone (e.g., -04:00:00)
 %:::z  numeric time zone with : to necessary precision (e.g., -04, +05:30)
 %Z     alphabetic time zone abbreviation (e.g., EDT)
-```
 
 By default, date pads numeric fields with zeroes.  The following optional flags may follow '%':
 
-```
 -      (hyphen) do not pad the field
 _      (underscore) pad with spaces
 0      (zero) pad with zeros
 +      pad with zeros, and put '+' before future years with >4 digits
 ^      use upper case if possible
 #      use opposite case if possible
-```
 
+
+
+You can check the original tests for code examples:
+* [date_posix.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/date_posix.ab)
 
 ## `now`
+
+```ab
+import { now } from "std/date.ab"
+```
+
 ```ab
 pub fun now(): Num 
 ```
 
-Returns the current timestamp (seconds since the Epoch (1970-01-01 00:00 UTC)).
+Return current timestamp (seconds since the Epoch (1970-01-01 00:00 UTC))
 
+
+
+You can check the original tests for code examples:
+* [now.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/now.ab)
+
+## `date_add`
+
+```ab
+import { date_add } from "std/date.ab"
+```
+
+```ab
+pub fun date_add(add: Text, date: Text = "", utc: Bool = false): Text ? 
+```
+
+EXPERIMENTAL
+Add value to date.
+If no date is specified, the current date is used
+Ex : date_add("+3 days")
+You can use :
+(+/-)
+years
+months
+days
+hours
+minutes
+seconds
+
+
+
+You can check the original tests for code examples:
+* [date_add.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/date_add.ab)
+
+EXPERIMENTAL
+
+
+Compare 2 date
+
+Return 1 if date_a is after date_b
+
+Return 0 if date_a and date_b is the same
+
+Return -1 if date_b is after date_a
+
+If date_b is not provided, current date will be used
+
+## `date_compare`
+
+```ab
+import { date_compare } from "std/date.ab"
+```
+
+```ab
+pub fun date_compare(date_a: Text, date_b: Text = "", utc: Bool = false): Num ? 
+```
+
+You can check the original tests for code examples:
+* [date_compare.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/date_compare.ab)
 

--- a/docs/0.3.5-alpha/stdlib/doc/env.md
+++ b/docs/0.3.5-alpha/stdlib/doc/env.md
@@ -1,7 +1,7 @@
 ## `get_env_var`
 
 ```ab
-import { get_env_var } from "std/env.ab"
+import { get_env_var } from "std/env"
 ```
 
 ```ab
@@ -18,7 +18,7 @@ You can check the original tests for code examples:
 ## `load_env_file`
 
 ```ab
-import { load_env_file } from "std/env.ab"
+import { load_env_file } from "std/env"
 ```
 
 ```ab
@@ -35,7 +35,7 @@ You can check the original tests for code examples:
 ## `shell_isset`
 
 ```ab
-import { shell_isset } from "std/env.ab"
+import { shell_isset } from "std/env"
 ```
 
 ```ab
@@ -52,7 +52,7 @@ You can check the original tests for code examples:
 ## `shell_constant_set`
 
 ```ab
-import { shell_constant_set } from "std/env.ab"
+import { shell_constant_set } from "std/env"
 ```
 
 ```ab
@@ -69,7 +69,7 @@ You can check the original tests for code examples:
 ## `shell_constant_get`
 
 ```ab
-import { shell_constant_get } from "std/env.ab"
+import { shell_constant_get } from "std/env"
 ```
 
 ```ab
@@ -86,7 +86,7 @@ You can check the original tests for code examples:
 ## `shell_var_set`
 
 ```ab
-import { shell_var_set } from "std/env.ab"
+import { shell_var_set } from "std/env"
 ```
 
 ```ab
@@ -103,7 +103,7 @@ You can check the original tests for code examples:
 ## `shell_var_get`
 
 ```ab
-import { shell_var_get } from "std/env.ab"
+import { shell_var_get } from "std/env"
 ```
 
 ```ab
@@ -120,7 +120,7 @@ You can check the original tests for code examples:
 ## `shell_unset`
 
 ```ab
-import { shell_unset } from "std/env.ab"
+import { shell_unset } from "std/env"
 ```
 
 ```ab
@@ -137,7 +137,7 @@ You can check the original tests for code examples:
 ## `is_command`
 
 ```ab
-import { is_command } from "std/env.ab"
+import { is_command } from "std/env"
 ```
 
 ```ab
@@ -154,7 +154,7 @@ You can check the original tests for code examples:
 ## `input`
 
 ```ab
-import { input } from "std/env.ab"
+import { input } from "std/env"
 ```
 
 ```ab
@@ -171,7 +171,7 @@ You can check the original tests for code examples:
 ## `confirm`
 
 ```ab
-import { confirm } from "std/env.ab"
+import { confirm } from "std/env"
 ```
 
 ```ab
@@ -189,7 +189,7 @@ You can check the original tests for code examples:
 ## `has_failed`
 
 ```ab
-import { has_failed } from "std/env.ab"
+import { has_failed } from "std/env"
 ```
 
 ```ab
@@ -206,7 +206,7 @@ You can check the original tests for code examples:
 ## `exit`
 
 ```ab
-import { exit } from "std/env.ab"
+import { exit } from "std/env"
 ```
 
 ```ab
@@ -219,7 +219,7 @@ Close the script
 ## `is_root`
 
 ```ab
-import { is_root } from "std/env.ab"
+import { is_root } from "std/env"
 ```
 
 ```ab
@@ -236,7 +236,7 @@ You can check the original tests for code examples:
 ## `printf`
 
 ```ab
-import { printf } from "std/env.ab"
+import { printf } from "std/env"
 ```
 
 ```ab
@@ -254,7 +254,7 @@ You can check the original tests for code examples:
 ## `printf_escape`
 
 ```ab
-import { printf_escape } from "std/env.ab"
+import { printf_escape } from "std/env"
 ```
 
 ```ab
@@ -271,7 +271,7 @@ You can check the original tests for code examples:
 ## `text_shell`
 
 ```ab
-import { text_shell } from "std/env.ab"
+import { text_shell } from "std/env"
 ```
 
 ```ab
@@ -288,7 +288,7 @@ You can check the original tests for code examples:
 ## `text_bold`
 
 ```ab
-import { text_bold } from "std/env.ab"
+import { text_bold } from "std/env"
 ```
 
 ```ab
@@ -305,7 +305,7 @@ You can check the original tests for code examples:
 ## `text_italic`
 
 ```ab
-import { text_italic } from "std/env.ab"
+import { text_italic } from "std/env"
 ```
 
 ```ab
@@ -322,7 +322,7 @@ You can check the original tests for code examples:
 ## `text_underlined`
 
 ```ab
-import { text_underlined } from "std/env.ab"
+import { text_underlined } from "std/env"
 ```
 
 ```ab
@@ -339,7 +339,7 @@ You can check the original tests for code examples:
 ## `color_echo`
 
 ```ab
-import { color_echo } from "std/env.ab"
+import { color_echo } from "std/env"
 ```
 
 ```ab
@@ -356,7 +356,7 @@ You can check the original tests for code examples:
 ## `echo_info`
 
 ```ab
-import { echo_info } from "std/env.ab"
+import { echo_info } from "std/env"
 ```
 
 ```ab
@@ -373,7 +373,7 @@ You can check the original tests for code examples:
 ## `echo_success`
 
 ```ab
-import { echo_success } from "std/env.ab"
+import { echo_success } from "std/env"
 ```
 
 ```ab
@@ -390,7 +390,7 @@ You can check the original tests for code examples:
 ## `echo_warning`
 
 ```ab
-import { echo_warning } from "std/env.ab"
+import { echo_warning } from "std/env"
 ```
 
 ```ab
@@ -407,7 +407,7 @@ You can check the original tests for code examples:
 ## `error`
 
 ```ab
-import { error } from "std/env.ab"
+import { error } from "std/env"
 ```
 
 ```ab

--- a/docs/0.3.5-alpha/stdlib/doc/env.md
+++ b/docs/0.3.5-alpha/stdlib/doc/env.md
@@ -1,62 +1,9 @@
-## `color_echo`
-```ab
-pub fun color_echo(message: Text, color: Num): Null 
-```
-
-Prints a text with a specified color.
-
-
-## `confirm`
-```ab
-pub fun confirm(prompt: Text, default_yes: Bool = false): Bool 
-```
-
-Creates a confirm prompt (Yes/No), and returns true if the choice is Yes.
-
-"No" is the default choice, set default_yes to true for "Yes" as default choice.
-
-
-## `echo_info`
-```ab
-pub fun echo_info(message: Text): Null 
-```
-
-Prints a text as a info message.
-
-
-## `echo_success`
-```ab
-pub fun echo_success(message: Text): Null 
-```
-
-Prints a text as a success message.
-
-
-## `echo_warning`
-```ab
-pub fun echo_warning(message: Text): Null 
-```
-
-Prints a text as a warning message.
-
-
-## `error`
-```ab
-pub fun error(message: Text, exit_code: Num = 1): Null 
-```
-
-Prints a text as a error and exits if the status code is greater than 0.
-
-
-## `exit`
-```ab
-pub fun exit(code: Num): Null 
-```
-
-Closes the script.
-
-
 ## `get_env_var`
+
+```ab
+import { get_env_var } from "std/env.ab"
+```
+
 ```ab
 pub fun get_env_var(var: Text, file: Text = ".env"): Text 
 ```
@@ -64,139 +11,413 @@ pub fun get_env_var(var: Text, file: Text = ".env"): Text
 Retrieves the value of an environment variable, optionally sourcing it from a file if not already set.
 
 
-## `has_failed`
-```ab
-pub fun has_failed(command: Text): Bool 
-```
 
-Checks if the command has failed.
-
-
-## `input`
-```ab
-pub fun input(prompt: Text): Text 
-```
-
-Creates a prompt and returns the value.
-
-
-## `is_command`
-```ab
-pub fun is_command(command: Text): Bool 
-```
-
-Checks if a command exists.
-
-
-## `is_root`
-```ab
-pub fun is_root(): Bool 
-```
-
-Checks if the script is running with a user with root permission.
-
+You can check the original tests for code examples:
+* [get_env_var.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/get_env_var.ab)
 
 ## `load_env_file`
+
+```ab
+import { load_env_file } from "std/env.ab"
+```
+
 ```ab
 pub fun load_env_file(file: Text = ".env"): Null 
 ```
 
-Loads the env file in the environment, using `xargs`.
+Load the env file in the environment, using `xargs`
 
 
-## `printf`
-```ab
-pub fun printf(format: Text, args: [Text] = [""]): Null 
-```
 
-`printf` the text following the arguments.
-
-
-## `printf_escape`
-```ab
-pub fun printf_escape(text: Text): Text 
-```
-
-Escapes the text to be used with `printf`.
-
-
-## `shell_constant_get`
-```ab
-pub fun shell_constant_get(name: Text): Text ? 
-```
-
-Gets a constant inside the shell session.
-
-
-## `shell_constant_set`
-```ab
-pub fun shell_constant_set(name: Text, val: Text): Null ? 
-```
-
-Sets a constant inside the shell session.
-
+You can check the original tests for code examples:
+* [load_env_file.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/load_env_file.ab)
 
 ## `shell_isset`
+
+```ab
+import { shell_isset } from "std/env.ab"
+```
+
 ```ab
 pub fun shell_isset(name: Text): Bool 
 ```
 
-Checks if a variable inside the shell session exists.
+Check if a variable inside the Shell session exist
 
 
-## `shell_unset`
+
+You can check the original tests for code examples:
+* [shell_isset.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/shell_isset.ab)
+
+## `shell_constant_set`
+
 ```ab
-pub fun shell_unset(name: Text): Null ? 
+import { shell_constant_set } from "std/env.ab"
 ```
 
-Removes a variable inside the shell session.
-
-
-## `shell_var_get`
 ```ab
-pub fun shell_var_get(name: Text): Text ? 
+pub fun shell_constant_set(name: Text, val: Text): Null ? 
 ```
 
-Gets a constant inside the shell session.
+Set a constant inside the Shell session
 
+
+
+You can check the original tests for code examples:
+* [shell_constant_set.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/shell_constant_set.ab)
+
+## `shell_constant_get`
+
+```ab
+import { shell_constant_get } from "std/env.ab"
+```
+
+```ab
+pub fun shell_constant_get(name: Text): Text ? 
+```
+
+Get a constant inside the Shell session
+
+
+
+You can check the original tests for code examples:
+* [shell_constant_get.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/shell_constant_get.ab)
 
 ## `shell_var_set`
+
+```ab
+import { shell_var_set } from "std/env.ab"
+```
+
 ```ab
 pub fun shell_var_set(name: Text, val: Text): Null ? 
 ```
 
-Sets a constant inside the shell session.
+Set a constant inside the Shell session
 
 
-## `text_bold`
+
+You can check the original tests for code examples:
+* [shell_var_set.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/shell_var_set.ab)
+
+## `shell_var_get`
+
 ```ab
-pub fun text_bold(message: Text): Text 
+import { shell_var_get } from "std/env.ab"
 ```
 
-Returns a text as bold.
-
-
-## `text_italic`
 ```ab
-pub fun text_italic(message: Text): Text 
+pub fun shell_var_get(name: Text): Text ? 
 ```
 
-Returns a text as italic.
+Get a constant inside the Shell session
 
+
+
+You can check the original tests for code examples:
+* [shell_var_get.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/shell_var_get.ab)
+
+## `shell_unset`
+
+```ab
+import { shell_unset } from "std/env.ab"
+```
+
+```ab
+pub fun shell_unset(name: Text): Null ? 
+```
+
+Remove a variable inside the Shell session
+
+
+
+You can check the original tests for code examples:
+* [shell_unset.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/shell_unset.ab)
+
+## `is_command`
+
+```ab
+import { is_command } from "std/env.ab"
+```
+
+```ab
+pub fun is_command(command: Text): Bool 
+```
+
+Check if the command exist
+
+
+
+You can check the original tests for code examples:
+* [is_command.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/is_command.ab)
+
+## `input`
+
+```ab
+import { input } from "std/env.ab"
+```
+
+```ab
+pub fun input(prompt: Text): Text 
+```
+
+Create a prompt and return the value
+
+
+
+You can check the original tests for code examples:
+* [input.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/input.ab)
+
+## `confirm`
+
+```ab
+import { confirm } from "std/env.ab"
+```
+
+```ab
+pub fun confirm(prompt: Text, default_yes: Bool = false): Bool 
+```
+
+Confirm prompt (Yes/No), return true if choice is Yes
+"No" is the default choice, set default_yes to true for "Yes" as default choice
+
+
+
+You can check the original tests for code examples:
+* [confirm.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/confirm.ab)
+
+## `has_failed`
+
+```ab
+import { has_failed } from "std/env.ab"
+```
+
+```ab
+pub fun has_failed(command: Text): Bool 
+```
+
+Checks if the command has failed
+
+
+
+You can check the original tests for code examples:
+* [has_failed.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/has_failed.ab)
+
+## `exit`
+
+```ab
+import { exit } from "std/env.ab"
+```
+
+```ab
+pub fun exit(code: Num): Null 
+```
+
+Close the script
+
+
+## `is_root`
+
+```ab
+import { is_root } from "std/env.ab"
+```
+
+```ab
+pub fun is_root(): Bool 
+```
+
+Check if the script is running with a user with root permission
+
+
+
+You can check the original tests for code examples:
+* [is_root.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/is_root.ab)
+
+## `printf`
+
+```ab
+import { printf } from "std/env.ab"
+```
+
+```ab
+pub fun printf(format: Text, args: [Text] = [""]): Null 
+```
+
+`printf` the text following the arguments
+
+
+
+You can check the original tests for code examples:
+* [printf.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/printf.ab)
+* [printf_escape.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/printf_escape.ab)
+
+## `printf_escape`
+
+```ab
+import { printf_escape } from "std/env.ab"
+```
+
+```ab
+pub fun printf_escape(text: Text): Text 
+```
+
+Escape the text to be used with `printf`
+
+
+
+You can check the original tests for code examples:
+* [printf_escape.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/printf_escape.ab)
 
 ## `text_shell`
+
+```ab
+import { text_shell } from "std/env.ab"
+```
+
 ```ab
 pub fun text_shell(message: Text, style: Num, fg: Num, bg: Num): Text 
 ```
 
-Prepares a text with formatting options for `printf`.
+Prepare a text with formatting options for `printf`
 
+
+
+You can check the original tests for code examples:
+* [text_shell.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/text_shell.ab)
+
+## `text_bold`
+
+```ab
+import { text_bold } from "std/env.ab"
+```
+
+```ab
+pub fun text_bold(message: Text): Text 
+```
+
+Return a text as bold
+
+
+
+You can check the original tests for code examples:
+* [text_bold.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/text_bold.ab)
+
+## `text_italic`
+
+```ab
+import { text_italic } from "std/env.ab"
+```
+
+```ab
+pub fun text_italic(message: Text): Text 
+```
+
+Return a text as italic
+
+
+
+You can check the original tests for code examples:
+* [text_italic.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/text_italic.ab)
 
 ## `text_underlined`
+
+```ab
+import { text_underlined } from "std/env.ab"
+```
+
 ```ab
 pub fun text_underlined(message: Text): Text 
 ```
 
-Returns a text as underlined.
+Return a text as underlined
 
+
+
+You can check the original tests for code examples:
+* [text_underlined.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/text_underlined.ab)
+
+## `color_echo`
+
+```ab
+import { color_echo } from "std/env.ab"
+```
+
+```ab
+pub fun color_echo(message: Text, color: Num): Null 
+```
+
+Print a text with a specified color
+
+
+
+You can check the original tests for code examples:
+* [color_echo.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/color_echo.ab)
+
+## `echo_info`
+
+```ab
+import { echo_info } from "std/env.ab"
+```
+
+```ab
+pub fun echo_info(message: Text): Null 
+```
+
+Print a text as Info
+
+
+
+You can check the original tests for code examples:
+* [echo_info.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/echo_info.ab)
+
+## `echo_success`
+
+```ab
+import { echo_success } from "std/env.ab"
+```
+
+```ab
+pub fun echo_success(message: Text): Null 
+```
+
+Print a text as Success
+
+
+
+You can check the original tests for code examples:
+* [echo_success.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/echo_success.ab)
+
+## `echo_warning`
+
+```ab
+import { echo_warning } from "std/env.ab"
+```
+
+```ab
+pub fun echo_warning(message: Text): Null 
+```
+
+Print a text as Warning
+
+
+
+You can check the original tests for code examples:
+* [echo_warning.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/echo_warning.ab)
+
+## `error`
+
+```ab
+import { error } from "std/env.ab"
+```
+
+```ab
+pub fun error(message: Text, exit_code: Num = 1): Null 
+```
+
+Print a text as Error and exit if the status code is greater than 0
+
+
+
+You can check the original tests for code examples:
+* [error.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/error.ab)
 

--- a/docs/0.3.5-alpha/stdlib/doc/fs.md
+++ b/docs/0.3.5-alpha/stdlib/doc/fs.md
@@ -1,81 +1,158 @@
-## `change_owner`
-```ab
-pub fun change_owner(user: Text, path: Text): Bool 
-```
-
-Changes the owner of a file.
-
-If the file doesn't exist, it returns `false`
-
-
-## `create_dir`
-```ab
-pub fun create_dir(path: Text): Null 
-```
-
-Creates a directory with all parent directories as required.
-
-
-## `create_symbolic_link`
-```ab
-pub fun create_symbolic_link(origin: Text, destination: Text): Bool 
-```
-
-Creates a symbolic link.
-
-If the file doesn't exist, it returns a boolean and prints a message.
-
-
 ## `dir_exist`
+
+```ab
+import { dir_exist } from "std/fs.ab"
+```
+
 ```ab
 pub fun dir_exist(path) 
 ```
 
-Checks if a directory exists.
+Check if directory exists
 
 
-## `file_append`
-```ab
-pub fun file_append(path, content) 
-```
 
-Appends content to a file.
-
-Doesn't check if the file exists.
-
+You can check the original tests for code examples:
+* [dir_exist.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/dir_exist.ab)
 
 ## `file_exist`
+
+```ab
+import { file_exist } from "std/fs.ab"
+```
+
 ```ab
 pub fun file_exist(path) 
 ```
 
-Checks if a file exists.
+Check if file exists
 
+
+
+You can check the original tests for code examples:
+* [file_exist.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/file_exist.ab)
 
 ## `file_read`
+
+```ab
+import { file_read } from "std/fs.ab"
+```
+
 ```ab
 pub fun file_read(path) 
 ```
 
-Gets file contents from a path.
+Get the file content
 
+
+
+You can check the original tests for code examples:
+* [file_read.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/file_read.ab)
 
 ## `file_write`
+
+```ab
+import { file_write } from "std/fs.ab"
+```
+
 ```ab
 pub fun file_write(path, content) 
 ```
 
-Writes content to a file.
+Write the content to the file
 Doesn't check if the file exist
 
 
+
+You can check the original tests for code examples:
+* [file_write.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/file_write.ab)
+
+## `file_append`
+
+```ab
+import { file_append } from "std/fs.ab"
+```
+
+```ab
+pub fun file_append(path, content) 
+```
+
+Append the content to the file
+Doesn't check if the file exist
+
+
+
+You can check the original tests for code examples:
+* [file_append.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/file_append.ab)
+
+## `create_symbolic_link`
+
+```ab
+import { create_symbolic_link } from "std/fs.ab"
+```
+
+```ab
+pub fun create_symbolic_link(origin: Text, destination: Text): Bool 
+```
+
+Create a symbolic link
+If the file doens't exist return a boolean and print a message
+
+
+
+You can check the original tests for code examples:
+* [create_symbolic_link.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/create_symbolic_link.ab)
+
+## `create_dir`
+
+```ab
+import { create_dir } from "std/fs.ab"
+```
+
+```ab
+pub fun create_dir(path: Text): Null 
+```
+
+Create a directory with all intermediate directories as required
+
+
+
+You can check the original tests for code examples:
+* [create_dir.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/create_dir.ab)
+
 ## `make_executable`
+
+```ab
+import { make_executable } from "std/fs.ab"
+```
+
 ```ab
 pub fun make_executable(path: Text): Bool 
 ```
 
-Sets a file as executable.
+Set the file as executable
+If the file doesn't exist return a boolean and print a message
 
-If the file doesn't exist, it returns a boolean and prints a message.
 
+
+You can check the original tests for code examples:
+* [make_executable.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/make_executable.ab)
+
+## `change_owner`
+
+```ab
+import { change_owner } from "std/fs.ab"
+```
+
+```ab
+pub fun change_owner(user: Text, path: Text): Bool 
+```
+
+Change the owner of the file
+If the file doesn't exist return false
+
+
+
+You can check the original tests for code examples:
+* [change_owner.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/change_owner.ab)
 

--- a/docs/0.3.5-alpha/stdlib/doc/fs.md
+++ b/docs/0.3.5-alpha/stdlib/doc/fs.md
@@ -1,7 +1,7 @@
 ## `dir_exist`
 
 ```ab
-import { dir_exist } from "std/fs.ab"
+import { dir_exist } from "std/fs"
 ```
 
 ```ab
@@ -18,7 +18,7 @@ You can check the original tests for code examples:
 ## `file_exist`
 
 ```ab
-import { file_exist } from "std/fs.ab"
+import { file_exist } from "std/fs"
 ```
 
 ```ab
@@ -35,7 +35,7 @@ You can check the original tests for code examples:
 ## `file_read`
 
 ```ab
-import { file_read } from "std/fs.ab"
+import { file_read } from "std/fs"
 ```
 
 ```ab
@@ -52,7 +52,7 @@ You can check the original tests for code examples:
 ## `file_write`
 
 ```ab
-import { file_write } from "std/fs.ab"
+import { file_write } from "std/fs"
 ```
 
 ```ab
@@ -70,7 +70,7 @@ You can check the original tests for code examples:
 ## `file_append`
 
 ```ab
-import { file_append } from "std/fs.ab"
+import { file_append } from "std/fs"
 ```
 
 ```ab
@@ -88,7 +88,7 @@ You can check the original tests for code examples:
 ## `create_symbolic_link`
 
 ```ab
-import { create_symbolic_link } from "std/fs.ab"
+import { create_symbolic_link } from "std/fs"
 ```
 
 ```ab
@@ -106,7 +106,7 @@ You can check the original tests for code examples:
 ## `create_dir`
 
 ```ab
-import { create_dir } from "std/fs.ab"
+import { create_dir } from "std/fs"
 ```
 
 ```ab
@@ -123,7 +123,7 @@ You can check the original tests for code examples:
 ## `make_executable`
 
 ```ab
-import { make_executable } from "std/fs.ab"
+import { make_executable } from "std/fs"
 ```
 
 ```ab
@@ -141,7 +141,7 @@ You can check the original tests for code examples:
 ## `change_owner`
 
 ```ab
-import { change_owner } from "std/fs.ab"
+import { change_owner } from "std/fs"
 ```
 
 ```ab

--- a/docs/0.3.5-alpha/stdlib/doc/http.md
+++ b/docs/0.3.5-alpha/stdlib/doc/http.md
@@ -1,11 +1,17 @@
 ## `download`
+
+```ab
+import { download } from "std/http.ab"
+```
+
 ```ab
 pub fun download(url: Text, path: Text): Bool 
 ```
 
 Downloads a file from a given URL and saves it to a specified path using available command-line tools.
 
-It checks for the availability of common command-line tools (`curl`, `wget`, and `aria2c`, in order) and uses the first available tool to perform the download.
+This function attempts to download a file from the provided URL and save it to the specified path.
+It checks for the availability of common command-line tools (`curl`, `wget`, and `aria2c`) and uses the first available tool to perform the download.
 If none of the tools are available, the function returns `false`.
 
 

--- a/docs/0.3.5-alpha/stdlib/doc/http.md
+++ b/docs/0.3.5-alpha/stdlib/doc/http.md
@@ -1,7 +1,7 @@
 ## `download`
 
 ```ab
-import { download } from "std/http.ab"
+import { download } from "std/http"
 ```
 
 ```ab

--- a/docs/0.3.5-alpha/stdlib/doc/math.md
+++ b/docs/0.3.5-alpha/stdlib/doc/math.md
@@ -1,40 +1,85 @@
-## `abs`
-```ab
-pub fun abs(number: Num): Num 
-```
-
-Returns the absolute value of a number
-
-
-## `ceil`
-```ab
-pub fun ceil(number: Num): Num 
-```
-
-Returns the smallest integer greater than or equal to a number
-
-
-## `floor`
-```ab
-pub fun floor(number: Num): Num 
-```
-
-Returns the largest integer less than or equal to a number
-
-
-## `round`
-```ab
-pub fun round(number: Num): Num 
-```
-
-Returns a number, rounded to the nearest integer
-
-
 ## `sum`
+
+```ab
+import { sum } from "std/math.ab"
+```
+
 ```ab
 pub fun sum(list: [Num]): Num 
 ```
 
-Sums an array's contents
+Sum the array content
 
+
+
+You can check the original tests for code examples:
+* [sum.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/sum.ab)
+
+## `round`
+
+```ab
+import { round } from "std/math.ab"
+```
+
+```ab
+pub fun round(number: Num): Num 
+```
+
+Returns the number rounded to the nearest integer
+
+
+
+You can check the original tests for code examples:
+* [round.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/round.ab)
+
+## `floor`
+
+```ab
+import { floor } from "std/math.ab"
+```
+
+```ab
+pub fun floor(number: Num): Num 
+```
+
+Returns the largest integer less than or equal to the number
+
+
+
+You can check the original tests for code examples:
+* [floor.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/floor.ab)
+
+## `ceil`
+
+```ab
+import { ceil } from "std/math.ab"
+```
+
+```ab
+pub fun ceil(number: Num): Num 
+```
+
+Returns the smallest integer greater than or equal to the number
+
+
+
+You can check the original tests for code examples:
+* [ceil.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/ceil.ab)
+
+## `abs`
+
+```ab
+import { abs } from "std/math.ab"
+```
+
+```ab
+pub fun abs(number: Num): Num 
+```
+
+Returns the absolute value of the number
+
+
+
+You can check the original tests for code examples:
+* [abs.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/abs.ab)
 

--- a/docs/0.3.5-alpha/stdlib/doc/math.md
+++ b/docs/0.3.5-alpha/stdlib/doc/math.md
@@ -1,7 +1,7 @@
 ## `sum`
 
 ```ab
-import { sum } from "std/math.ab"
+import { sum } from "std/math"
 ```
 
 ```ab
@@ -18,7 +18,7 @@ You can check the original tests for code examples:
 ## `round`
 
 ```ab
-import { round } from "std/math.ab"
+import { round } from "std/math"
 ```
 
 ```ab
@@ -35,7 +35,7 @@ You can check the original tests for code examples:
 ## `floor`
 
 ```ab
-import { floor } from "std/math.ab"
+import { floor } from "std/math"
 ```
 
 ```ab
@@ -52,7 +52,7 @@ You can check the original tests for code examples:
 ## `ceil`
 
 ```ab
-import { ceil } from "std/math.ab"
+import { ceil } from "std/math"
 ```
 
 ```ab
@@ -69,7 +69,7 @@ You can check the original tests for code examples:
 ## `abs`
 
 ```ab
-import { abs } from "std/math.ab"
+import { abs } from "std/math"
 ```
 
 ```ab

--- a/docs/0.3.5-alpha/stdlib/doc/text.md
+++ b/docs/0.3.5-alpha/stdlib/doc/text.md
@@ -1,12 +1,356 @@
-## `capitalize`
+## `replace_once`
+
 ```ab
-pub fun capitalize(text: Text): Text 
+import { replace_once } from "std/text.ab"
 ```
 
-Capitalize the first letter of the given `text`.
+```ab
+pub fun replace_once(source, pattern, replacement) 
+```
 
+Finds the first occurrence of a pettern in the content and replaces it with provided replacement text
+
+
+
+You can check the original tests for code examples:
+* [replace_once.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/replace_once.ab)
+
+## `replace`
+
+```ab
+import { replace } from "std/text.ab"
+```
+
+```ab
+pub fun replace(source, pattern, replacement) 
+```
+
+Replaces all occurences of a pattern in the content with provided replacement text
+
+
+
+You can check the original tests for code examples:
+* [replace.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/replace.ab)
+* [replace_once.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/replace_once.ab)
+* [replace_regex.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/replace_regex.ab)
+
+## `replace_regex`
+
+```ab
+import { replace_regex } from "std/text.ab"
+```
+
+```ab
+pub fun replace_regex(source: Text, pattern: Text, replacement: Text): Text 
+```
+
+Replaces all occurences of a regex pattern in the content with provided replacement text
+
+Function uses `sed`
+
+
+
+You can check the original tests for code examples:
+* [replace_regex.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/replace_regex.ab)
+
+## `split`
+
+```ab
+import { split } from "std/text.ab"
+```
+
+```ab
+pub fun split(text: Text, delimiter: Text): [Text] 
+```
+
+This function splits the input `text` into an array of substrings using the specified `delimiter`.
+
+
+
+You can check the original tests for code examples:
+* [split.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/split.ab)
+* [split_multiline.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/split_multiline.ab)
+
+## `lines`
+
+```ab
+import { lines } from "std/text.ab"
+```
+
+```ab
+pub fun lines(text: Text): [Text] 
+```
+
+Splits a `text` into an array of substrings based on newline characters.
+
+
+
+You can check the original tests for code examples:
+* [lines.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/lines.ab)
+
+## `words`
+
+```ab
+import { words } from "std/text.ab"
+```
+
+```ab
+pub fun words(text: Text): [Text] 
+```
+
+Splits a `text` into an array of substrings based on space character.
+
+
+## `join`
+
+```ab
+import { join } from "std/text.ab"
+```
+
+```ab
+pub fun join(list: [Text], delimiter: Text): Text 
+```
+
+Merge a text using the delimeter specified
+
+
+
+You can check the original tests for code examples:
+* [join.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/join.ab)
+
+## `trim_left`
+
+```ab
+import { trim_left } from "std/text.ab"
+```
+
+```ab
+pub fun trim_left(text: Text): Text 
+```
+
+Trim the spaces at top of the text using `sed`
+
+
+
+You can check the original tests for code examples:
+* [trim_left.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/trim_left.ab)
+
+## `trim_right`
+
+```ab
+import { trim_right } from "std/text.ab"
+```
+
+```ab
+pub fun trim_right(text: Text): Text 
+```
+
+Trim the spaces at end of the text using `sed`
+
+
+
+You can check the original tests for code examples:
+* [trim_right.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/trim_right.ab)
+
+## `trim`
+
+```ab
+import { trim } from "std/text.ab"
+```
+
+```ab
+pub fun trim(text: Text): Text 
+```
+
+Trim the spaces from the text input
+
+
+
+You can check the original tests for code examples:
+* [trim.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/trim.ab)
+* [trim_left.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/trim_left.ab)
+* [trim_right.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/trim_right.ab)
+
+## `lower`
+
+```ab
+import { lower } from "std/text.ab"
+```
+
+```ab
+pub fun lower(text: Text): Text 
+```
+
+Lowercase the text input using `tr`
+
+
+
+You can check the original tests for code examples:
+* [lower.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/lower.ab)
+
+## `upper`
+
+```ab
+import { upper } from "std/text.ab"
+```
+
+```ab
+pub fun upper(text: Text): Text 
+```
+
+Lowercase the text input using `tr`
+
+
+
+You can check the original tests for code examples:
+* [upper.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/upper.ab)
+
+## `parse`
+
+```ab
+import { parse } from "std/text.ab"
+```
+
+```ab
+pub fun parse(text: Text): Num ? 
+```
+
+Attempts to parse a given text into a number, returning the parsed number or zero if parsing fails.
+
+
+
+You can check the original tests for code examples:
+* [parse.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/parse.ab)
+
+## `chars`
+
+```ab
+import { chars } from "std/text.ab"
+```
+
+```ab
+pub fun chars(text: Text): [Text] 
+```
+
+Splits a text into an array of individual characters.
+
+
+
+You can check the original tests for code examples:
+* [chars.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/chars.ab)
+
+## `len`
+
+```ab
+import { len } from "std/text.ab"
+```
+
+```ab
+pub fun len(value): Num 
+```
+
+Get the text or array length
+
+
+
+You can check the original tests for code examples:
+* [len_list.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/len_list.ab)
+* [len_string.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/len_string.ab)
+
+## `contains`
+
+```ab
+import { contains } from "std/text.ab"
+```
+
+```ab
+pub fun contains(text: Text, phrase: Text): Bool 
+```
+
+Check if text contain the value
+
+
+
+You can check the original tests for code examples:
+* [contains.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/contains.ab)
+
+## `reverse`
+
+```ab
+import { reverse } from "std/text.ab"
+```
+
+```ab
+pub fun reverse(text: Text): Text 
+```
+
+Reverse a text using `rev`
+
+
+
+You can check the original tests for code examples:
+* [reverse.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/reverse.ab)
+
+## `starts_with`
+
+```ab
+import { starts_with } from "std/text.ab"
+```
+
+```ab
+pub fun starts_with(text: Text, prefix: Text): Bool 
+```
+
+Check if text starts with a value
+
+
+
+You can check the original tests for code examples:
+* [starts_with.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/starts_with.ab)
+
+## `ends_with`
+
+```ab
+import { ends_with } from "std/text.ab"
+```
+
+```ab
+pub fun ends_with(text: Text, suffix: Text): Bool 
+```
+
+Check if text ends with a value
+
+
+
+You can check the original tests for code examples:
+* [ends_with.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/ends_with.ab)
+
+## `slice`
+
+```ab
+import { slice } from "std/text.ab"
+```
+
+```ab
+pub fun slice(text: Text, index: Num, length: Num = 0): Text 
+```
+
+Returns a substring from `text` starting at the given `index` (0-based).
+If `index` is negative, the substring starts from the end of `text` based on the absolute value of `index`.
+If `length` is provided, the substring will include `length` characters; otherwise, it slices to the end of `text`.
+If `length` is negative, an empty string is returned.
+
+
+
+You can check the original tests for code examples:
+* [slice.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/slice.ab)
 
 ## `char_at`
+
+```ab
+import { char_at } from "std/text.ab"
+```
+
 ```ab
 pub fun char_at(text: Text, index: Num): Text 
 ```
@@ -15,63 +359,33 @@ Returns the character from `text` at the specified `index` (0-based).
 If `index` is negative, the substring starts from the end of `text` based on the absolute value of `index`.
 
 
-## `chars`
+
+You can check the original tests for code examples:
+* [char_at.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/char_at.ab)
+
+## `capitalize`
+
 ```ab
-pub fun chars(text: Text): [Text] 
+import { capitalize } from "std/text.ab"
 ```
 
-Splits a text into an array of individual characters.
-
-
-## `contains`
 ```ab
-pub fun contains(text: Text, phrase: Text): Bool 
+pub fun capitalize(text: Text): Text 
 ```
 
-Checks if some text contains a value/
+Capitalize the first letter of the given `text`
 
 
-## `ends_with`
-```ab
-pub fun ends_with(text: Text, suffix: Text): Bool 
-```
 
-Checks if text ends with a value.
-
-
-## `join`
-```ab
-pub fun join(list: [Text], delimiter: Text): Text 
-```
-
-Merges text using the delimeter specified.
-
-
-## `len`
-```ab
-pub fun len(value): Num 
-```
-
-Gets the length of provided text or array.
-
-
-## `lines`
-```ab
-pub fun lines(text: Text): [Text] 
-```
-
-Splits a `text` into an array of substrings based on newline characters.
-
-
-## `lower`
-```ab
-pub fun lower(text: Text): Text 
-```
-
-Makes the text input lowercase using `tr`.
-
+You can check the original tests for code examples:
+* [capitalize.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/capitalize.ab)
 
 ## `lpad`
+
+```ab
+import { lpad } from "std/text.ab"
+```
+
 ```ab
 pub fun lpad(text: Text, pad: Text, length: Num): Text 
 ```
@@ -79,49 +393,16 @@ pub fun lpad(text: Text, pad: Text, length: Num): Text
 Pads `text` with the specified `pad` character on left until it reaches the desired `length`.
 
 
-## `parse`
-```ab
-pub fun parse(text: Text): Num ? 
-```
 
-Attempts to parse a given text into a number, returning the parsed number or zero if parsing fails.
-
-
-## `replace`
-```ab
-pub fun replace(source, pattern, replacement) 
-```
-
-Replaces all occurences of a pattern in the content with the provided replacement text.
-
-
-## `replace_once`
-```ab
-pub fun replace_once(source, pattern, replacement) 
-```
-
-Finds the first occurrence of a pettern in the content and replaces it with the provided replacement text.
-
-
-## `replace_regex`
-```ab
-pub fun replace_regex(source: Text, pattern: Text, replacement: Text, extended: Bool = false): Text 
-```
-
-Replaces all occurences of a regex pattern in the content with the provided replacement text.
-
-Function uses `sed`
-
-
-## `reverse`
-```ab
-pub fun reverse(text: Text): Text 
-```
-
-Reverses text using `rev`.
-
+You can check the original tests for code examples:
+* [lpad.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/lpad.ab)
 
 ## `rpad`
+
+```ab
+import { rpad } from "std/text.ab"
+```
+
 ```ab
 pub fun rpad(text: Text, pad: Text, length: Num): Text 
 ```
@@ -129,79 +410,24 @@ pub fun rpad(text: Text, pad: Text, length: Num): Text
 Pads `text` with the specified `pad` character on the right until it reaches the desired `length`.
 
 
-## `slice`
-```ab
-pub fun slice(text: Text, index: Num, length: Num = 0): Text 
-```
 
-Returns a substring from `text` starting at the given `index` (0-based).
-
-If `index` is negative, the substring starts from the end of `text` based on the absolute value of `index`.
-If `length` is provided, the substring will include `length` characters; otherwise, it slices to the end of `text`.
-If `length` is negative, an empty string is returned.
-
-
-## `split`
-```ab
-pub fun split(text: Text, delimiter: Text): [Text] 
-```
-
-Splits the input `text` into an array of substrings using the specified `delimiter`.
-
-
-## `starts_with`
-```ab
-pub fun starts_with(text: Text, prefix: Text): Bool 
-```
-
-Checks if text starts with a value.
-
-
-## `trim`
-```ab
-pub fun trim(text: Text): Text 
-```
-
-Trims the spaces from the text input.
-
-
-## `trim_left`
-```ab
-pub fun trim_left(text: Text): Text 
-```
-
-Trims the spaces at top of the text using `sed`.
-
-
-## `trim_right`
-```ab
-pub fun trim_right(text: Text): Text 
-```
-
-Trims the spaces at end of the text using `sed`.
-
-
-## `upper`
-```ab
-pub fun upper(text: Text): Text 
-```
-
-Makes the text input uppercase using `tr`.
-
-
-## `words`
-```ab
-pub fun words(text: Text): [Text] 
-```
-
-Splits a `text` into an array of substrings based on space character.
-
+You can check the original tests for code examples:
+* [rpad.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/rpad.ab)
 
 ## `zfill`
+
+```ab
+import { zfill } from "std/text.ab"
+```
+
 ```ab
 pub fun zfill(text: Text, length: Num): Text 
 ```
 
 Pads `text` with zeros on the left until it reaches the desired `length`.
 
+
+
+You can check the original tests for code examples:
+* [zfill.ab](https://github.com/amber-lang/amber/blob/0.3.5-alpha/src/tests/stdlib/zfill.ab)
 

--- a/docs/0.3.5-alpha/stdlib/doc/text.md
+++ b/docs/0.3.5-alpha/stdlib/doc/text.md
@@ -1,7 +1,7 @@
 ## `replace_once`
 
 ```ab
-import { replace_once } from "std/text.ab"
+import { replace_once } from "std/text"
 ```
 
 ```ab
@@ -18,7 +18,7 @@ You can check the original tests for code examples:
 ## `replace`
 
 ```ab
-import { replace } from "std/text.ab"
+import { replace } from "std/text"
 ```
 
 ```ab
@@ -37,7 +37,7 @@ You can check the original tests for code examples:
 ## `replace_regex`
 
 ```ab
-import { replace_regex } from "std/text.ab"
+import { replace_regex } from "std/text"
 ```
 
 ```ab
@@ -56,7 +56,7 @@ You can check the original tests for code examples:
 ## `split`
 
 ```ab
-import { split } from "std/text.ab"
+import { split } from "std/text"
 ```
 
 ```ab
@@ -74,7 +74,7 @@ You can check the original tests for code examples:
 ## `lines`
 
 ```ab
-import { lines } from "std/text.ab"
+import { lines } from "std/text"
 ```
 
 ```ab
@@ -91,7 +91,7 @@ You can check the original tests for code examples:
 ## `words`
 
 ```ab
-import { words } from "std/text.ab"
+import { words } from "std/text"
 ```
 
 ```ab
@@ -104,7 +104,7 @@ Splits a `text` into an array of substrings based on space character.
 ## `join`
 
 ```ab
-import { join } from "std/text.ab"
+import { join } from "std/text"
 ```
 
 ```ab
@@ -121,7 +121,7 @@ You can check the original tests for code examples:
 ## `trim_left`
 
 ```ab
-import { trim_left } from "std/text.ab"
+import { trim_left } from "std/text"
 ```
 
 ```ab
@@ -138,7 +138,7 @@ You can check the original tests for code examples:
 ## `trim_right`
 
 ```ab
-import { trim_right } from "std/text.ab"
+import { trim_right } from "std/text"
 ```
 
 ```ab
@@ -155,7 +155,7 @@ You can check the original tests for code examples:
 ## `trim`
 
 ```ab
-import { trim } from "std/text.ab"
+import { trim } from "std/text"
 ```
 
 ```ab
@@ -174,7 +174,7 @@ You can check the original tests for code examples:
 ## `lower`
 
 ```ab
-import { lower } from "std/text.ab"
+import { lower } from "std/text"
 ```
 
 ```ab
@@ -191,7 +191,7 @@ You can check the original tests for code examples:
 ## `upper`
 
 ```ab
-import { upper } from "std/text.ab"
+import { upper } from "std/text"
 ```
 
 ```ab
@@ -208,7 +208,7 @@ You can check the original tests for code examples:
 ## `parse`
 
 ```ab
-import { parse } from "std/text.ab"
+import { parse } from "std/text"
 ```
 
 ```ab
@@ -225,7 +225,7 @@ You can check the original tests for code examples:
 ## `chars`
 
 ```ab
-import { chars } from "std/text.ab"
+import { chars } from "std/text"
 ```
 
 ```ab
@@ -242,7 +242,7 @@ You can check the original tests for code examples:
 ## `len`
 
 ```ab
-import { len } from "std/text.ab"
+import { len } from "std/text"
 ```
 
 ```ab
@@ -260,7 +260,7 @@ You can check the original tests for code examples:
 ## `contains`
 
 ```ab
-import { contains } from "std/text.ab"
+import { contains } from "std/text"
 ```
 
 ```ab
@@ -277,7 +277,7 @@ You can check the original tests for code examples:
 ## `reverse`
 
 ```ab
-import { reverse } from "std/text.ab"
+import { reverse } from "std/text"
 ```
 
 ```ab
@@ -294,7 +294,7 @@ You can check the original tests for code examples:
 ## `starts_with`
 
 ```ab
-import { starts_with } from "std/text.ab"
+import { starts_with } from "std/text"
 ```
 
 ```ab
@@ -311,7 +311,7 @@ You can check the original tests for code examples:
 ## `ends_with`
 
 ```ab
-import { ends_with } from "std/text.ab"
+import { ends_with } from "std/text"
 ```
 
 ```ab
@@ -328,7 +328,7 @@ You can check the original tests for code examples:
 ## `slice`
 
 ```ab
-import { slice } from "std/text.ab"
+import { slice } from "std/text"
 ```
 
 ```ab
@@ -348,7 +348,7 @@ You can check the original tests for code examples:
 ## `char_at`
 
 ```ab
-import { char_at } from "std/text.ab"
+import { char_at } from "std/text"
 ```
 
 ```ab
@@ -366,7 +366,7 @@ You can check the original tests for code examples:
 ## `capitalize`
 
 ```ab
-import { capitalize } from "std/text.ab"
+import { capitalize } from "std/text"
 ```
 
 ```ab
@@ -383,7 +383,7 @@ You can check the original tests for code examples:
 ## `lpad`
 
 ```ab
-import { lpad } from "std/text.ab"
+import { lpad } from "std/text"
 ```
 
 ```ab
@@ -400,7 +400,7 @@ You can check the original tests for code examples:
 ## `rpad`
 
 ```ab
-import { rpad } from "std/text.ab"
+import { rpad } from "std/text"
 ```
 
 ```ab
@@ -417,7 +417,7 @@ You can check the original tests for code examples:
 ## `zfill`
 
 ```ab
-import { zfill } from "std/text.ab"
+import { zfill } from "std/text"
 ```
 
 ```ab


### PR DESCRIPTION
I've generated the files using the following command.

```
# Start on the amber-lang/amber repository
git checkout 0.3.5-alpha
git cherry-pick 9fe0f18
# At this point, I resolved conflicts using a text editor

# Generate docs
# Note: 0.3.5 does not have `--usage` option for --docs, the usage will be automatically added when `#[cfg(not(debug_assertions))]`.
cargo build &&\
	./target/debug/amber -e 'import * from "std/text"; unsafe $ shopt -s globstar $; loop v in split((unsafe $ ls src/std/**/*.ab $), "\n") { unsafe $ ./target/debug/amber --docs "{v}" "docs/stdlib/doc/" $ }'
cp src/std/docs/stdlib/doc/* ../amber-docs/docs/0.3.5-alpha/stdlib/doc/

# Replace links
sed -i 's?blob/master/?blob/0.3.5-alpha/' ../amber-docs/docs/0.3.5-alpha/stdlib/doc/*
# Remove the extension .ab from import statements. I think this is a bug
sed -i -E 's/^(import .+ from "std\/.+)\.ab"$/\1"/g' ../amber-docs/docs/0.3.5-alpha/stdlib/doc/*
```