### PR TITLE
Show all versions in preview

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,9 @@
     "defaultVersion": "0.3.5-alpha",
     "visibleVersions": [
         "0.3.5-alpha"
+    ],
+    "allVersions": [
+        "0.3.5-alpha",
+        "0.4.0-alpha"
     ]
 }

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -32,6 +32,10 @@ export default function Navigation({ hideSearch = false }: Props) {
         setThemeMode(mode === 'light' ? 'dark' : 'light')
     }
 
+    const versions = process.env.NEXT_PUBLIC_ENVIRONMENT === "production"
+        ? config.visibleVersions
+        : config.allVersions
+
     return <>
             <div className={style.nav}>
                 <div className={style.left}>
@@ -47,7 +51,7 @@ export default function Navigation({ hideSearch = false }: Props) {
                         <Dropdown
                             value={version}
                             onChange={(value: Object) => router.push(`/${value.toString()}`)}
-                            options={config.visibleVersions}
+                            options={versions}
                             getLabel={(option: Object) => (option.toString()).replace(/-(alpha|beta)/, "")}
                         />
                     </div>


### PR DESCRIPTION
This PR adds a functionality that shows all versions if certain environment variable is set to `"production"`. The variable must be prefixed with `NEXT_PUBLIC` so that it can be accessed through the client component.