### PR TITLE
Add migration guide to version 0.4.0

### DIFF
--- a/docs/0.4.0-alpha/getting_started/migration_guide.md
+++ b/docs/0.4.0-alpha/getting_started/migration_guide.md
@@ -16,7 +16,7 @@ unsafe $ ls -a $
 trust $ ls -a $
 ```
 
-# Iterator Loop keyword rename
+# Rename of `loop` Keyword for Iterator Loop
 
 To align with standards and improve readability, the `loop` keyword used for iterator loops has been replaced with `for`. This change ensures linguistic consistency and adopts a convention widely recognized across many programming languages.
 

--- a/docs/0.4.0-alpha/getting_started/migration_guide.md
+++ b/docs/0.4.0-alpha/getting_started/migration_guide.md
@@ -117,89 +117,89 @@ Below is a table of all the functions that have been renamed. Their functionalit
 
 ### `std/array`
 
-Module    |New Name             |Old Name
-----------|---------------------|---------------------
-std/array |array_contains       |includes
-std/array |array_extract_at     |extract_at
-std/array |array_find           |array_first_index
-std/array |array_find_all       |array_search
-std/array |array_first          |first
-std/array |array_last           |last
-std/array |aray_pop             |op
-std/array |array_remove_at      |remove_at
-std/array |array_shift          |shift
+New Name             |Old Name
+---------------------|---------------------
+array_contains       |includes
+array_extract_at     |extract_at
+array_find           |array_first_index
+array_find_all       |array_search
+array_first          |first
+array_last           |last
+aray_pop             |op
+array_remove_at      |remove_at
+array_shift          |shift
 
 ### `std/date`
 
-Module    |New Name             |Old Name
-----------|---------------------|---------------------
-std/date  |date_now             |now
+New Name             |Old Name
+---------------------|---------------------
+date_now             |now
 
 ### `std/env`
 
-Module    |New Name             |Old Name
-----------|---------------------|---------------------
-std/env   |bold                 |text_bold
-std/env   |echo_colored         |color_echo
-std/env   |echo_error           |error
-std/env   |env_const_get        |shell_constant_get
-std/env   |env_const_set        |shell_constant_set
-std/env   |env_file_load        |load_env_file
-std/env   |env_var_get          |shell_var_get
-std/env   |env_var_load         |get_env_var
-std/env   |env_var_set          |shell_var_set
-std/env   |env_var_test         |shell_isset
-std/env   |env_var_unset        |shell_unset
-std/env   |escaped              |printf_escape
-std/env   |input_confirm        |confirm
-std/env   |input_prompt         |input
-std/env   |italic               |text_italic
-std/env   |styled               |text_shell
-std/env   |underlined           |text_underlined
+New Name             |Old Name
+---------------------|---------------------
+bold                 |text_bold
+echo_colored         |color_echo
+echo_error           |error
+env_const_get        |shell_constant_get
+env_const_set        |shell_constant_set
+env_file_load        |load_env_file
+env_var_get          |shell_var_get
+env_var_load         |get_env_var
+env_var_set          |shell_var_set
+env_var_test         |shell_isset
+env_var_unset        |shell_unset
+escaped              |printf_escape
+input_confirm        |confirm
+input_prompt         |input
+italic               |text_italic
+styled               |text_shell
+underlined           |text_underlined
 
 ### `std/fs`
 
-Module    |New Name             |Old Name
-----------|---------------------|---------------------
-std/fs    |dir_create           |create_dir
-std/fs    |dir_exists           |dir_exist
-std/fs    |file_chmod           |make_executable
-std/fs    |file_chown           |change_owner
-std/fs    |file_exists          |file_exist
-std/fs    |file_extract         |extract
-std/fs    |file_glob            |glob
-std/fs    |file_glob_all        |glob_multiple
-std/fs    |symlink_create       |create_symbolic_link
+New Name             |Old Name
+---------------------|---------------------
+dir_create           |create_dir
+dir_exists           |dir_exist
+file_chmod           |make_executable
+file_chown           |change_owner
+file_exists          |file_exist
+file_extract         |extract
+file_glob            |glob
+file_glob_all        |glob_multiple
+symlink_create       |create_symbolic_link
 
 ### `std/http`
 
-Module    |New Name             |Old Name
-----------|---------------------|---------------------
-std/http  |file_download        |download
+New Name             |Old Name
+---------------------|---------------------
+file_download        |download
 
 ### `std/math`
 
-Module    |New Name             |Old Name
-----------|---------------------|---------------------
-std/math  |std/maths            |abs
-std/math  |math_ceil            |ceil
-std/math  |math_floor           |floor
-std/math  |math_round           |round
-std/math  |math_sum             |sum
+New Name             |Old Name
+---------------------|---------------------
+std/maths            |abs
+math_ceil            |ceil
+math_floor           |floor
+math_round           |round
+math_sum             |sum
 
 ### `std/text`
 
-Module    |New Name             |Old Name
-----------|---------------------|---------------------
-std/text  |capitalized          |capitalize
-std/text  |lowercase            |lower
-std/text  |match_regex_any      |match_any_regex
-std/text  |parse_number         |parse
-std/text  |replace_one          |replace_once
-std/text  |reversed             |reverse
-std/text  |split_chars          |chars
-std/text  |split_words          |words
-std/text  |text_contains        |contains
-std/text  |text_contains_all    |contains_all
-std/text  |text_contains_any    |contains_any
-std/text  |uppercase            |upper
+New Name             |Old Name
+---------------------|---------------------
+capitalized          |capitalize
+lowercase            |lower
+match_regex_any      |match_any_regex
+parse_number         |parse
+replace_one          |replace_once
+reversed             |reverse
+split_chars          |chars
+split_words          |words
+text_contains        |contains
+text_contains_all    |contains_all
+text_contains_any    |contains_any
+uppercase            |upper

--- a/docs/0.4.0-alpha/getting_started/migration_guide.md
+++ b/docs/0.4.0-alpha/getting_started/migration_guide.md
@@ -1,0 +1,205 @@
+This guide provides a step-by-step walkthrough for migrating code from 0.3.5-alpha to 0.4.0-alpha. The current version introduces several breaking changes. This document outlines the modifications, explains how to adapt your code to maintain the same behavior, and highlights updated features. In this guide we will cover two main categories of changes:
+1.	**Language Features**: Changes and updates to the core language syntax and semantics.
+2.	**Standard Library Updates**: Modifications to existing standard library functions and their usage.
+
+Follow along to ensure a smooth transition to the new version. Let’s get started!
+
+# Command
+
+The command can potentially fail. In the previous version the `unsafe` keyword was used to indicate that this command's failure should be ignored. In this release we renamed this keyword to `trust`, to better convey intent.
+
+```ab
+// Before
+unsafe $ ls -a $
+
+// After
+trust $ ls -a $
+```
+
+# Iterator loop
+
+To align with standards and improve readability, the `loop` keyword used for iterator loops has been replaced with `for`. This change ensures linguistic consistency and adopts a convention widely recognized across many programming languages.
+
+```ab
+// Before
+loop number in 0..=5 {
+    echo number
+}
+
+// After
+for number in 0..=5 {
+    echo number
+}
+```
+
+# Builtin
+
+We've introduced new builtins `len`, `exit` and `lines`, replacing their equivalents in the standard library.
+
+## Len
+
+To emphasize that `len` supports multiple data types, such as text and arrays, it has been moved to a builtin.
+
+```ab
+// Before
+import { len } from "std/text"
+echo len("Hello there!")
+echo len([1, 2, 3])
+
+// After
+echo len("Hello there!")
+echo len([1, 2, 3])
+```
+
+## Exit
+
+Exit is used so often that we decided to move it as a separate built-in as well. It's implemented as a builtin statement which means that we can remove the parentheses.
+
+```ab
+// Before
+import { exit } from "std/env"
+exit(1)
+
+// After
+exit 1
+```
+
+## Lines
+
+Lines was not only moved into a built-in but also it was changed in functionality. Before it accepted a `Text` value which then was splited by new line characters. In this version the newly added builtin accepts a path to file for which it returns each line.
+
+```ab
+// Before
+import { lines } from "std/text"
+import { file_read } from "std/fs"
+lines(file_read("/path/to/file"))
+
+// After
+lines("/path/to/file")
+```
+
+> DETAILS: This built-in is specifically optimized for direct use as an iterator in a for loop. When used this way, it does not load the entire file into memory but processes it line by line, ensuring efficient resource usage.
+
+For scenarios where lines was used on a `Text` value originating from sources other than a file, it is recommended to use the new standard library function `split_lines` instead.
+
+```ab
+// Before
+import { lines } from "std/text"
+lines(long_text)
+
+// After
+import { split_lines } from "std/text"
+split_lines(long_text)
+```
+
+
+# Standard Library
+
+In order to keep a consistent standard library function naming, most of the functions have been renamed with one exception.
+
+## Make executable (`make_executable`)
+
+This function has been removed in favor of `file_chmod`. The same effect can be achieved when used with `+x` flag.
+
+```ab
+// Before
+import { make_executable } from "std/fs"
+make_executable("script.ab")
+
+// After
+import { file_chmod } from "std/fs"
+file_chmod("script.ab", "+x")
+```
+
+## Renamed functions
+
+Below is a table of all the functions that have been renamed. Their functionality and definitions remain unchanged.
+
+### `std/array`
+
+Module    |New Name             |Old Name
+----------|---------------------|---------------------
+std/array |array_contains       |includes
+std/array |array_extract_at     |extract_at
+std/array |array_find           |array_first_index
+std/array |array_find_all       |array_search
+std/array |array_first          |first
+std/array |array_last           |last
+std/array |aray_pop             |op
+std/array |array_remove_at      |remove_at
+std/array |array_shift          |shift
+
+### `std/date`
+
+Module    |New Name             |Old Name
+----------|---------------------|---------------------
+std/date  |date_now             |now
+
+### `std/env`
+
+Module    |New Name             |Old Name
+----------|---------------------|---------------------
+std/env   |bold                 |text_bold
+std/env   |echo_colored         |color_echo
+std/env   |echo_error           |error
+std/env   |env_const_get        |shell_constant_get
+std/env   |env_const_set        |shell_constant_set
+std/env   |env_file_load        |load_env_file
+std/env   |env_var_get          |shell_var_get
+std/env   |env_var_load         |get_env_var
+std/env   |env_var_set          |shell_var_set
+std/env   |env_var_test         |shell_isset
+std/env   |env_var_unset        |shell_unset
+std/env   |escaped              |printf_escape
+std/env   |input_confirm        |confirm
+std/env   |input_prompt         |input
+std/env   |italic               |text_italic
+std/env   |styled               |text_shell
+std/env   |underlined           |text_underlined
+
+### `std/fs`
+
+Module    |New Name             |Old Name
+----------|---------------------|---------------------
+std/fs    |dir_create           |create_dir
+std/fs    |dir_exists           |dir_exist
+std/fs    |file_chmod           |make_executable
+std/fs    |file_chown           |change_owner
+std/fs    |file_exists          |file_exist
+std/fs    |file_extract         |extract
+std/fs    |file_glob            |glob
+std/fs    |file_glob_all        |glob_multiple
+std/fs    |symlink_create       |create_symbolic_link
+
+### `std/http`
+
+Module    |New Name             |Old Name
+----------|---------------------|---------------------
+std/http  |file_download        |download
+
+### `std/math`
+
+Module    |New Name             |Old Name
+----------|---------------------|---------------------
+std/math  |std/maths            |abs
+std/math  |math_ceil            |ceil
+std/math  |math_floor           |floor
+std/math  |math_round           |round
+std/math  |math_sum             |sum
+
+### `std/text`
+
+Module    |New Name             |Old Name
+----------|---------------------|---------------------
+std/text  |capitalized          |capitalize
+std/text  |lowercase            |lower
+std/text  |match_regex_any      |match_any_regex
+std/text  |parse_number         |parse
+std/text  |replace_one          |replace_once
+std/text  |reversed             |reverse
+std/text  |split_chars          |chars
+std/text  |split_words          |words
+std/text  |text_contains        |contains
+std/text  |text_contains_all    |contains_all
+std/text  |text_contains_any    |contains_any
+std/text  |uppercase            |upper

--- a/docs/0.4.0-alpha/getting_started/migration_guide.md
+++ b/docs/0.4.0-alpha/getting_started/migration_guide.md
@@ -1,10 +1,10 @@
 This guide provides a step-by-step walkthrough for migrating code from 0.3.5-alpha to 0.4.0-alpha. The current version introduces several breaking changes. This document outlines the modifications, explains how to adapt your code to maintain the same behavior, and highlights updated features. In this guide we will cover two main categories of changes:
-1.	**Language Features**: Changes and updates to the core language syntax and semantics.
-2.	**Standard Library Updates**: Modifications to existing standard library functions and their usage.
+1. **Language Features**: Changes and updates to the core language syntax and semantics.
+2. **Standard Library Updates**: Modifications to existing standard library functions and their usage.
 
 Follow along to ensure a smooth transition to the new version. Let’s get started!
 
-# Command
+# Rename of `unsafe` Command Modifier
 
 The command can potentially fail. In the previous version the `unsafe` keyword was used to indicate that this command's failure should be ignored. In this release we renamed this keyword to `trust`, to better convey intent.
 
@@ -16,7 +16,7 @@ unsafe $ ls -a $
 trust $ ls -a $
 ```
 
-# Iterator loop
+# Iterator Loop keyword rename
 
 To align with standards and improve readability, the `loop` keyword used for iterator loops has been replaced with `for`. This change ensures linguistic consistency and adopts a convention widely recognized across many programming languages.
 
@@ -32,7 +32,7 @@ for number in 0..=5 {
 }
 ```
 
-# Builtin
+# New Builtins
 
 We've introduced new builtins `len`, `exit` and `lines`, replacing their equivalents in the standard library.
 
@@ -53,7 +53,7 @@ echo len([1, 2, 3])
 
 ## Exit
 
-Exit is used so often that we decided to move it as a separate built-in as well. It's implemented as a builtin statement which means that we can remove the parentheses.
+Exit is used so often that we decided to move it as a separate builtin as well. It's implemented as a builtin statement which means that we can remove the parentheses.
 
 ```ab
 // Before
@@ -66,7 +66,7 @@ exit 1
 
 ## Lines
 
-Lines was not only moved into a built-in but also it was changed in functionality. Before it accepted a `Text` value which then was splited by new line characters. In this version the newly added builtin accepts a path to file for which it returns each line.
+Lines was not only moved into a builtin but also it was changed in functionality. Before it accepted a `Text` value which was then split by newline characters. In this version the newly added builtin accepts a path to file for which it returns each line.
 
 ```ab
 // Before
@@ -78,7 +78,7 @@ lines(file_read("/path/to/file"))
 lines("/path/to/file")
 ```
 
-> DETAILS: This built-in is specifically optimized for direct use as an iterator in a for loop. When used this way, it does not load the entire file into memory but processes it line by line, ensuring efficient resource usage.
+> DETAILS: This builtin is specifically optimized for direct use as an iterator in a `for` loop. When used this way, it does not load the entire file into memory but processes it line by line, ensuring efficient resource usage.
 
 For scenarios where lines was used on a `Text` value originating from sources other than a file, it is recommended to use the new standard library function `split_lines` instead.
 
@@ -92,12 +92,11 @@ import { split_lines } from "std/text"
 split_lines(long_text)
 ```
 
-
 # Standard Library
 
 In order to keep a consistent standard library function naming, most of the functions have been renamed with one exception.
 
-## Make executable (`make_executable`)
+## Make Executable (`make_executable`)
 
 This function has been removed in favor of `file_chmod`. The same effect can be achieved when used with `+x` flag.
 
@@ -111,7 +110,7 @@ import { file_chmod } from "std/fs"
 file_chmod("script.ab", "+x")
 ```
 
-## Renamed functions
+## Renamed Functions
 
 Below is a table of all the functions that have been renamed. Their functionality and definitions remain unchanged.
 
@@ -181,7 +180,7 @@ file_download        |download
 
 New Name             |Old Name
 ---------------------|---------------------
-std/maths            |abs
+math_abs             |abs
 math_ceil            |ceil
 math_floor           |floor
 math_round           |round

--- a/docs/0.4.0-alpha/getting_started/migration_guide.md
+++ b/docs/0.4.0-alpha/getting_started/migration_guide.md
@@ -125,7 +125,7 @@ array_find           |array_first_index
 array_find_all       |array_search
 array_first          |first
 array_last           |last
-aray_pop             |op
+array_pop            |pop
 array_remove_at      |remove_at
 array_shift          |shift
 

--- a/docs/0.4.0-alpha/index.json
+++ b/docs/0.4.0-alpha/index.json
@@ -5,16 +5,16 @@
             "title": "Getting Started",
             "docs": [
                 {
-                    "path": "getting_started/migration_guide",
-                    "title": "Migration Guide"
-                },
-                {
                     "path": "getting_started/installation",
                     "title": "Installation"
                 },
                 {
                     "path": "getting_started/usage",
                     "title": "Usage"
+                },
+                {
+                    "path": "getting_started/migration_guide",
+                    "title": "Migration Guide"
                 }
             ]
         },

--- a/docs/0.4.0-alpha/index.json
+++ b/docs/0.4.0-alpha/index.json
@@ -5,6 +5,10 @@
             "title": "Getting Started",
             "docs": [
                 {
+                    "path": "getting_started/migration_guide",
+                    "title": "Migration Guide"
+                },
+                {
                     "path": "getting_started/installation",
                     "title": "Installation"
                 },

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -15,7 +15,7 @@ export default async function Post({ params }: Props) {
     const location = getLocation(params.slug)
     if (location.slug.length == 0) return (
         <VersionProvider version={location.version}>
-            <Main />
+            <Main location={location} />
         </VersionProvider>
     )
     const document = await getDocument(location.fullPath)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,47 +7,48 @@ import SidebarProvider from '@/contexts/DocumentContext/SidebarProvider'
 import TopLoader from '@/components/TopLoader/TopLoader'
 import VersionProvider from '@/contexts/VersionContext/VersionProvider'
 import config from '@/../config.json'
+import SideBar from '@/components/SideBar/SideBar'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Amber Documentation',
-  description: 'Documentation for Amber programming language',
-  openGraph: {
     title: 'Amber Documentation',
-    siteName: 'Documentation for Amber programming language',
-    type: 'website',
-    images: [
-      {
-          url: 'https://docs.amber-lang.com/og.jpeg'
-      }
-    ]
-  }
+    description: 'Documentation for Amber programming language',
+    openGraph: {
+        title: 'Amber Documentation',
+        siteName: 'Documentation for Amber programming language',
+        type: 'website',
+        images: [
+            {
+                url: 'https://docs.amber-lang.com/og.jpeg'
+            }
+        ]
+    }
 }
 
 export default function RootLayout({
-  children,
+    children,
 }: {
-  children: React.ReactNode
+    children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <head>
-        <link rel='icon' href='/internal/favicon.png'/>
-        <meta name='view-transition' content='same-origin'/>
-      </head>
-      <body className={inter.className}>
-        <ThemeProvider>
-          <SidebarProvider>
-            <TopLoader />
-            <VersionProvider version={config.defaultVersion}>
-                <main>
-                {children}
-                </main>
-            </VersionProvider>
-          </SidebarProvider>
-        </ThemeProvider>
-      </body>
-    </html>
-  )
+        <html lang="en">
+            <head>
+            <link rel='icon' href='/internal/favicon.png'/>
+            <meta name='view-transition' content='same-origin'/>
+            </head>
+            <body className={inter.className}>
+                <ThemeProvider>
+                    <SidebarProvider>
+                        <TopLoader />
+                        <VersionProvider version={config.defaultVersion}>
+                                <main>
+                                    {children}
+                                </main>
+                        </VersionProvider>
+                    </ SidebarProvider>
+                </ThemeProvider>
+            </body>
+        </html>
+    )
 }

--- a/src/components/Markdown/Markdown.module.css
+++ b/src/components/Markdown/Markdown.module.css
@@ -35,12 +35,55 @@
 
 .markdown table {
     border-spacing: 0;
-    border-collapse: collapse;
+    border-collapse: separate;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.markdown table th {
+    background-color: var(--code-background);
+}
+
+.markdown table td {
+    color: color-mix(in srgb, var(--text), var(--border) 50%)
 }
 
 .markdown table th, .markdown table td {
+    border-bottom: 1px solid var(--border);
+    border-right: 1px solid var(--border);
     padding: 6px 13px;
-    border: 1px solid var(--border);
+}
+
+.markdown table tr th {
+    border-top: 1px solid var(--border);
+}
+
+.markdown table tr th:first-child,
+.markdown table tr td:first-child {
+    border-left: 1px solid var(--border);
+}
+
+.markdown table tr:hover {
+    background-color: var(--code-background);
+}
+
+.markdown table tr:first-child th:first-child {
+    border-top-left-radius: 0.5rem;
+}
+
+
+.markdown table tr:first-child th:last-child {
+    border-top-right-radius: 0.5rem;
+}
+
+
+.markdown table tr:last-child td:first-child {
+    border-bottom-left-radius: 0.5rem;
+}
+
+
+.markdown table tr:last-child td:last-child {
+    border-bottom-right-radius: 0.5rem;
 }
 
 .light-dark img:last-child {

--- a/src/views/Main/Main.tsx
+++ b/src/views/Main/Main.tsx
@@ -13,11 +13,11 @@ import { Location } from "@/utils/urls";
 const AmberScene = dynamic(() => import("@/components/AmberScene/AmberScene"), { ssr: false });
 
 interface Props {
-    location: Location;
+    location?: Location;
 }
 
 export default async function Main({ location }: Props) {
-    const toc = await getTableOfContents(location.version);
+    const toc = await getTableOfContents(location?.version);
 
     return (
         <NavigationLayout hideSearch>

--- a/src/views/Main/Main.tsx
+++ b/src/views/Main/Main.tsx
@@ -9,10 +9,15 @@ import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import NavigationLayout from "@/layouts/NavigationLayout/NavigationLayout";
 import MainBigLink from "@/layouts/MainBigLink/MainBigLink";
+import { Location } from "@/utils/urls";
 const AmberScene = dynamic(() => import("@/components/AmberScene/AmberScene"), { ssr: false });
 
-export default async function Main() {
-    const toc = await getTableOfContents();
+interface Props {
+    location: Location;
+}
+
+export default async function Main({ location }: Props) {
+    const toc = await getTableOfContents(location.version);
 
     return (
         <NavigationLayout hideSearch>

--- a/src/views/Page/Page.tsx
+++ b/src/views/Page/Page.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 
 export default async function Page({ location, document }: Props) {
-    const toc = await getTableOfContents()
+    const toc = await getTableOfContents(location.version)
     const docDesc = getDocDescriptor(toc, location.slug.join('/'))
     const flatToc = getFlatTableOfContents(toc)
 


### PR DESCRIPTION
This PR introduces:
- New migration guide from 0.3.5 to 0.4.0
- Improved table style to match the website's design
- Fixed issue with different sections between different versions of the documentation not appearing