### PR TITLE
test: Remove `/` from the beginings of paths

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
     paths:
-      - /docs/*/getting_started/new_changes.md
-      - /docs/*/getting_started/whats_new.md
-      - /docs/*/getting_started/migration_guide.md
+      - docs/*/getting_started/new_changes.md
+      - docs/*/getting_started/whats_new.md
+      - docs/*/getting_started/migration_guide.md
 
 jobs:
   get-commits:


### PR DESCRIPTION
It was my fault, the workflow totally does not run.

Tested on my fork.

<img width="719" height="493" alt="image" src="https://github.com/user-attachments/assets/36789daa-3987-4fee-8232-5aaa6a83c456" />
