### PR TITLE
fix: Opening curly bracket should be escaped

### DIFF
--- a/docs/0.5.0-alpha/getting_started/whats_new.md
+++ b/docs/0.5.0-alpha/getting_started/whats_new.md
@@ -261,7 +261,7 @@ sudo trust silent $ systemctl status nginx $
 - Fixed an issue where arguments of the main function could be shadowed, ensuring globally unique IDs for main function arguments. Thanks [@lens0021](https://github.com/lens0021). <!-- #796 -->
 - Corrected interpolation within single-quoted strings in commands, resolving issues where interpolated values were not properly parsed. Thanks [@lens0021](https://github.com/lens0021). For example:
   ```ab
-  trust $ echo '{"a":1, "b":2}' | jq '.["b"]' $
+  trust $ echo '\{"a":1, "b":2}' | jq '.["b"]' $
   ```
   This example now correctly prints `2`.<!-- #808 #814 -->
 


### PR DESCRIPTION
- `trust $ echo '\{"a":1, "b":2}' | jq '.["b"]' $` -> `2`
- `trust $ echo '{"a":1, "b":2}' | jq '.["b"]' $` ->  ERROR  Unexpected token