### PR TITLE
docs: Add reversed ranges, sudo modifier, and improve silent description

### DIFF
--- a/docs/0.5.0-alpha/basic_syntax/arrays.md
+++ b/docs/0.5.0-alpha/basic_syntax/arrays.md
@@ -11,6 +11,15 @@ echo 0..=10
 // Outputs: 0 1 2 3 4 5 6 7 8 9 10
 ```
 
+Ranges also support reversed order:
+
+```ab
+echo 6..3
+// Outputs: 6 5 4
+echo 6..=3
+// Outputs: 6 5 4 3
+```
+
 # Arrays
 
 We learned about array literals in the first chapter. In this chapter we will learn how to make use of them. Arrays are indexed from zero.

--- a/docs/0.5.0-alpha/basic_syntax/commands.md
+++ b/docs/0.5.0-alpha/basic_syntax/commands.md
@@ -24,7 +24,7 @@ echo result
 
 > DETAILS: Command expression result is sent to the variable instead of _standard output_.
 
-Command can also be interpolated with other expressions and variables
+Command can also be interpolated with other expressions and variables.
 
 ```ab
 let file_path = "/path/to/file"
@@ -94,8 +94,9 @@ To learn more about fail keyword, please read the article covering [failures](/b
 # Command Modifiers
 
 Command modifier is a keyword that alters the behavior of a command. Here are some examples:
-- `silent` - prevents command from displaying the result to the standard output.
+- `silent` - suppresses all output from a command (both stdout and stderr).
 - `trust` - disables Amber's mechanism that requires user to handle failures.
+- `sudo` - intelligently handles privilege escalation, detecting at runtime whether sudo is necessary and available.
 
 You can learn more details about each command modifier in the forthcoming chapters.
 
@@ -129,8 +130,16 @@ This will be treated the same way Bash treats statements. If it fails, then carr
 
 ## Silencing Commands
 
-You can easily silent given command. Here is an example usage:
+The `silent` modifier suppresses all output from a command, including both standard output (stdout) and standard error (stderr). This is equivalent to redirecting output to `/dev/null 2>&1` in bash.
 
 ```ab
 silent $ very loud command $
+```
+
+## Sudo
+
+The `sudo` modifier intelligently handles privilege escalation. It automatically detects at runtime whether `sudo` is necessary and available.
+
+```ab
+sudo $ systemctl restart nginx $
 ```


### PR DESCRIPTION
- Added reversed range examples to `basic_syntax/arrays.md`
- Added sudo modifier documentation to `basic_syntax/commands.md`
- Improved silent modifier description to clarify it suppresses both stdout and stderr

## Changes
- **arrays.md**: Added examples showing reversed ranges (e.g., `6..3`, `6..=3`)
- **commands.md**: Added sudo modifier to command modifiers list and new Sudo section with examples
- **commands.md**: Updated silent modifier description based on source code analysis (`>/dev/null 2>&1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)