### PR TITLE
Update arrays.md to remove outdated warning

### DIFF
--- a/docs/0.6.0-alpha/basic_syntax/arrays.md
+++ b/docs/0.6.0-alpha/basic_syntax/arrays.md
@@ -24,8 +24,6 @@ echo groceries[1]
 // Outputs: banana
 ```
 
-> WARNING: As of right now (Amber alpha) the subscript syntax does not work with expressions. This means that we can't evaluate expressions like `foo()[0]` yet.
-
 We can also _echo_ an entire array:
 
 ```ab


### PR DESCRIPTION
Removed warning about subscript syntax limitations which is resolved at https://github.com/amber-lang/amber/pull/855