### PR TITLE
Update installation.md for external tools integration

### DIFF
--- a/docs/0.5.1-alpha/getting_started/installation.md
+++ b/docs/0.5.1-alpha/getting_started/installation.md
@@ -113,7 +113,7 @@ sudo mkdir /opt /usr/local/bin
 
 ## Integration of external tools
 
-Amber is currently an alpha-stage project, and to implement some features, we have chosen to integrate external tools.
+Amber is currently an alpha-stage project, and to implement some features, we have chosen to integrate external tools.  
 If these tools are available on your system, they will be executed at the end of the Bash compilation process.
 
 * [bshchk](https://github.com/b1ek/bshchk): A runtime Bash dependency checker


### PR DESCRIPTION
This reintroduces the needed whitespace to render the linebreak accurately. 

(Markdown requires two spaces trailing, to render a newline, as a newline. I don't know who had that idea, but burn yourself with your morning coffee. 😝 )