### PR TITLE
Add information about bin (v0.6.0)

### DIFF
--- a/docs/0.6.0-alpha/getting_started/installation.md
+++ b/docs/0.6.0-alpha/getting_started/installation.md
@@ -23,8 +23,7 @@ Make sure that the operating system meets the following prerequisites
 - `curl` and `bash` are both installed by default in most cases. 
   In the very rare case that they happen to be not available yet, download them as well.
 
-> DETAILS: You should always update the system before you install a package in a rolling release distro, such as **Arch** and **Tumbleweed.**  
-Always reboot after an update of the kernel, init system, and similar software as well. 
+> DETAILS: You should always update the system before you install a package in a rolling release distro, such as **Arch** and **Tumbleweed.**  Always reboot after an update of the kernel, init system, and similar software as well. 
 
 ## Installation via `bin`, the binary package manager
 


### PR DESCRIPTION
Expanded installation instructions for various platforms and added notes on prerequisites and usage of the 'bin' package manager.