### PR TITLE
Fix code rendering

### DIFF
--- a/docs/0.3.5-alpha/contribute/guide_book.md
+++ b/docs/0.3.5-alpha/contribute/guide_book.md
@@ -29,8 +29,7 @@ Please open any syntax module code file, and find a line that says: `impl Syntax
 
 It will have a `parse()` function, where all the magic happens. You can either dig into the code yourself or look at the example below to understand how it works.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example parser
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -47,7 +46,8 @@ fn parse(meta: &mut ParserMetadata) -> SyntaxResult {
     Ok(())
 }
 ```
-</details>
+
+end[details]
 
 ### 2.2. Translator
 
@@ -55,8 +55,7 @@ Same as parser open a syntax module, and find a line that says `impl TranslateMo
 
 Same as before, you can either dig into the code you opened or look at the example below.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example translator
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -68,7 +67,8 @@ fn translate() -> String {
     format!("(( {} + {} ))", self.digit_1, self.digit_2)
 }
 ```
-</details>
+
+end[details]
 
 Basically, the `translate()` method should return a `String` for the compiler to construct a compiled file from all of them. If it translates to nothing, you should output an empty string, like `String::new()`
 
@@ -88,8 +88,7 @@ echo "Hello World"
 
 For a real example based on this guide you can check the [`cd` builtin](https://github.com/amber-lang/amber/blob/master/src/modules/builtin/cd.rs) that is also Failable.
 
-<details>
-<summary>Let's start!</summary>
+begin[details] Let's start!
 
 Create a `src/modules/builtin/builtin.rs` file with the following content:
 
@@ -116,6 +115,7 @@ pub struct Example {
     // This particular built-in contains a single expression
     value: Expr,
     // failed: Failed // You need this if you want that is failable
+    // }
 }
 
 // This is an implementation of a trait that creates a parser for this module
@@ -198,7 +198,8 @@ impl Statement {
     // ...
 }
 ```
-</details>
+
+end[details]
 
 Don't forget to add a test in the [https://github.com/amber-lang/amber/tree/master/src/tests/validity](`validity`) folder and to add the new builtin to the list of the [reserved keywords](https://github.com/amber-lang/amber/blob/master/src/modules/variable/mod.rs#L16).
 
@@ -222,8 +223,7 @@ Tests will be executed without recompilation. Amber will load the scripts and ve
 
 Some tests require additional setup, such as those for `download` that needs Rust to load a web server. These functions require special tests written in Rust that we can find in `src/tests/stdlib.rs` file.
 
-<details>
-<summary>Let's write a simple test</summary>
+begin[details] Let's write a simple test
 
 ```rs
 #[test]
@@ -234,4 +234,5 @@ fn prints_hi() {
     test_amber!(code, "hi!");
 }
 ```
-</details>
+
+end[details]

--- a/docs/0.4.0-alpha/contribute/guide_book.md
+++ b/docs/0.4.0-alpha/contribute/guide_book.md
@@ -29,8 +29,7 @@ Please open any syntax module code file, and find a line that says: `impl Syntax
 
 It will have a `parse()` function, where all the magic happens. You can either dig into the code yourself or look at the example below to understand how it works.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example parser
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -47,7 +46,8 @@ fn parse(meta: &mut ParserMetadata) -> SyntaxResult {
     Ok(())
 }
 ```
-</details>
+
+end[details]
 
 ### 2.2. Translator
 
@@ -55,8 +55,7 @@ Same as parser open a syntax module, and find a line that says `impl TranslateMo
 
 Same as before, you can either dig into the code you opened or look at the example below.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example translator
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -68,7 +67,8 @@ fn translate() -> String {
     format!("(( {} + {} ))", self.digit_1, self.digit_2)
 }
 ```
-</details>
+
+end[details]
 
 Basically, the `translate()` method should return a `String` for the compiler to construct a compiled file from all of them. If it translates to nothing, you should output an empty string, like `String::new()`
 
@@ -88,8 +88,7 @@ echo "Hello World"
 
 For a real example based on this guide you can check the [`cd` builtin](https://github.com/amber-lang/amber/blob/master/src/modules/builtin/cd.rs) that is also Failable.
 
-<details>
-<summary>Let's start!</summary>
+begin[details] Let's start!
 
 Create a `src/modules/builtin/builtin.rs` file with the following content:
 
@@ -116,6 +115,7 @@ pub struct Example {
     // This particular built-in contains a single expression
     value: Expr,
     // failed: Failed // You need this if you want that is failable
+    // }
 }
 
 // This is an implementation of a trait that creates a parser for this module
@@ -198,7 +198,8 @@ impl Statement {
     // ...
 }
 ```
-</details>
+
+end[details]
 
 Don't forget to add a test in the [https://github.com/amber-lang/amber/tree/master/src/tests/validity](`validity`) folder and to add the new builtin to the list of the [reserved keywords](https://github.com/amber-lang/amber/blob/master/src/modules/variable/mod.rs#L16).
 
@@ -222,8 +223,7 @@ Tests will be executed without recompilation. Amber will load the scripts and ve
 
 Some tests require additional setup, such as those for `download` that needs Rust to load a web server. These functions require special tests written in Rust that we can find in `src/tests/stdlib.rs` file.
 
-<details>
-<summary>Let's write a simple test</summary>
+begin[details] Let's write a simple test
 
 ```rs
 #[test]
@@ -234,4 +234,5 @@ fn prints_hi() {
     test_amber!(code, "hi!");
 }
 ```
-</details>
+
+end[details]

--- a/docs/0.5.1-alpha/contribute/guide_book.md
+++ b/docs/0.5.1-alpha/contribute/guide_book.md
@@ -29,8 +29,7 @@ Please open any syntax module code file, and find a line that says: `impl Syntax
 
 It will have a `parse()` function, where all the magic happens. You can either dig into the code yourself or look at the example below to understand how it works.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example parser
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -47,7 +46,8 @@ fn parse(meta: &mut ParserMetadata) -> SyntaxResult {
     Ok(())
 }
 ```
-</details>
+
+end[details]
 
 ### 2.2. Translator
 
@@ -55,8 +55,7 @@ Same as parser open a syntax module, and find a line that says `impl TranslateMo
 
 Same as before, you can either dig into the code you opened or look at the example below.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example translator
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -68,7 +67,8 @@ fn translate() -> String {
     format!("(( {} + {} ))", self.digit_1, self.digit_2)
 }
 ```
-</details>
+
+end[details]
 
 Basically, the `translate()` method should return a `String` for the compiler to construct a compiled file from all of them. If it translates to nothing, you should output an empty string, like `String::new()`
 
@@ -88,8 +88,7 @@ echo "Hello World"
 
 For a real example based on this guide you can check the [`cd` builtin](https://github.com/amber-lang/amber/blob/master/src/modules/builtin/cd.rs) that is also Failable.
 
-<details>
-<summary>Let's start!</summary>
+begin[details] Let's start!
 
 Create a `src/modules/builtin/builtin.rs` file with the following content:
 
@@ -109,6 +108,8 @@ use crate::translate::module::TranslateModule;
 use crate::utils::{ParserMetadata, TranslateMetadata};
 // Documentation module tells compiler what markdown content should it generate for this syntax module. This is irrelevent to our simple module so we will just return empty string.
 use crate::docs::module::DocumentationModule;
+// This is a macro that simplifies using `RawFragment` which is a very commonly used fragment in Amber
+use crate::raw_fragment;
 
 // This is a declaration of your built-in. Set the name accordingly.
 #[derive(Debug, Clone)]
@@ -132,8 +133,8 @@ impl SyntaxModule<ParserMetadata> for Echo {
     }
 
     // This is a function that will parse this syntax module "Built-in". It returns SyntaxResult which is a `Result<(), Failure>` where the `Failure` is an Heraclitus primitive that returns an error. It can be either:
-    - `Quiet` - which means that this is not the right syntax module to parse
-    - `Loud` - which means that this is the correct syntax module but there is some critical error in the code that halts the entire compilation process
+    // - `Quiet` - which means that this is not the right syntax module to parse
+    // - `Loud` - which means that this is the correct syntax module but there is some critical error in the code that halts the entire compilation process
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         // `token` parses a token `builtin` which is basically a command name for our built-in.
         // If we add `?` in the end of the heraclitus provided function - this function will return a quiet error.
@@ -147,14 +148,29 @@ impl SyntaxModule<ParserMetadata> for Echo {
     }
 }
 
+// Here we check if types match
+impl TypeCheckModule for Example {
+    // Here we define the valid typecheck function. The String returns the current line.
+    fn typecheck(&self, meta: &mut TranslateMetadata) -> SyntaxResult {
+        // Here we run the typecheck function on inner value to let it resolve its type
+        let value = self.value.typecheck(meta);
+        // We return a loud error if the type is not Text
+        if value.get_type() != Type::Text {
+            let pos = self.value.get_position();
+            error!(meta, pos, "Expected 'Text' type, got {}", value.get_type());
+        }
+        Ok(())
+    }
+}
+
 // Here we implement the translator for the syntax module. Here we return valid Bash or sh code. Set the name accordingly.
 impl TranslateModule for Example {
     // Here we define the valid translate function. The String returns the current line.
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         // Here we run the translate function on the syntax module `Expr`
         let value = self.value.translate(meta);
-        // Here we return the Bash code
-        format!("echo {}", value)
+        // Here we return the Bash code in a form of a `RawFragment`
+        raw_fragment!("echo {}", value)
     }
 }
 
@@ -198,7 +214,8 @@ impl Statement {
     // ...
 }
 ```
-</details>
+
+end[details]
 
 Don't forget to add a test in the [https://github.com/amber-lang/amber/tree/master/src/tests/validity](`validity`) folder and to add the new builtin to the list of the [reserved keywords](https://github.com/amber-lang/amber/blob/master/src/modules/variable/mod.rs#L16).
 
@@ -222,8 +239,7 @@ Tests will be executed without recompilation. Amber will load the scripts and ve
 
 Some tests require additional setup, such as those for `download` that needs Rust to load a web server. These functions require special tests written in Rust that we can find in `src/tests/stdlib.rs` file.
 
-<details>
-<summary>Let's write a simple test</summary>
+begin[details] Let's write a simple test
 
 ```rs
 #[test]
@@ -234,4 +250,5 @@ fn prints_hi() {
     test_amber!(code, "hi!");
 }
 ```
-</details>
+
+end[details]

--- a/docs/0.6.0-alpha/contribute/guide_book.md
+++ b/docs/0.6.0-alpha/contribute/guide_book.md
@@ -29,8 +29,7 @@ Please open any syntax module code file, and find a line that says: `impl Syntax
 
 It will have a `parse()` function, where all the magic happens. You can either dig into the code yourself or look at the example below to understand how it works.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example parser
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -47,7 +46,8 @@ fn parse(meta: &mut ParserMetadata) -> SyntaxResult {
     Ok(())
 }
 ```
-</details>
+
+end[details]
 
 ### 2.2. Translator
 
@@ -55,8 +55,7 @@ Same as parser open a syntax module, and find a line that says `impl TranslateMo
 
 Same as before, you can either dig into the code you opened or look at the example below.
 
-<details>
-<summary>Example parser</summary>
+begin[details] Example translator
 
 **Important: this is pseudo code. Its purpose is to demonstrate how it should look like.**
 
@@ -68,7 +67,8 @@ fn translate() -> String {
     format!("(( {} + {} ))", self.digit_1, self.digit_2)
 }
 ```
-</details>
+
+end[details]
 
 Basically, the `translate()` method should return a `String` for the compiler to construct a compiled file from all of them. If it translates to nothing, you should output an empty string, like `String::new()`
 
@@ -88,8 +88,7 @@ echo "Hello World"
 
 For a real example based on this guide you can check the [`cd` builtin](https://github.com/amber-lang/amber/blob/master/src/modules/builtin/cd.rs) that is also Failable.
 
-<details>
-<summary>Let's start!</summary>
+begin[details] Let's start!
 
 Create a `src/modules/builtin/builtin.rs` file with the following content:
 
@@ -109,6 +108,8 @@ use crate::translate::module::TranslateModule;
 use crate::utils::{ParserMetadata, TranslateMetadata};
 // Documentation module tells compiler what markdown content should it generate for this syntax module. This is irrelevent to our simple module so we will just return empty string.
 use crate::docs::module::DocumentationModule;
+// This is a macro that simplifies using `RawFragment` which is a very commonly used fragment in Amber
+use crate::raw_fragment;
 
 // This is a declaration of your built-in. Set the name accordingly.
 #[derive(Debug, Clone)]
@@ -132,8 +133,8 @@ impl SyntaxModule<ParserMetadata> for Echo {
     }
 
     // This is a function that will parse this syntax module "Built-in". It returns SyntaxResult which is a `Result<(), Failure>` where the `Failure` is an Heraclitus primitive that returns an error. It can be either:
-    - `Quiet` - which means that this is not the right syntax module to parse
-    - `Loud` - which means that this is the correct syntax module but there is some critical error in the code that halts the entire compilation process
+    // - `Quiet` - which means that this is not the right syntax module to parse
+    // - `Loud` - which means that this is the correct syntax module but there is some critical error in the code that halts the entire compilation process
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         // `token` parses a token `builtin` which is basically a command name for our built-in.
         // If we add `?` in the end of the heraclitus provided function - this function will return a quiet error.
@@ -147,14 +148,29 @@ impl SyntaxModule<ParserMetadata> for Echo {
     }
 }
 
+// Here we check if types match
+impl TypeCheckModule for Example {
+    // Here we define the valid typecheck function. The String returns the current line.
+    fn typecheck(&self, meta: &mut TranslateMetadata) -> SyntaxResult {
+        // Here we run the typecheck function on inner value to let it resolve its type
+        let value = self.value.typecheck(meta);
+        // We return a loud error if the type is not Text
+        if value.get_type() != Type::Text {
+            let pos = self.value.get_position();
+            error!(meta, pos, "Expected 'Text' type, got {}", value.get_type());
+        }
+        Ok(())
+    }
+}
+
 // Here we implement the translator for the syntax module. Here we return valid Bash or sh code. Set the name accordingly.
 impl TranslateModule for Example {
     // Here we define the valid translate function. The String returns the current line.
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         // Here we run the translate function on the syntax module `Expr`
         let value = self.value.translate(meta);
-        // Here we return the Bash code
-        format!("echo {}", value)
+        // Here we return the Bash code in a form of a `RawFragment`
+        raw_fragment!("echo {}", value)
     }
 }
 
@@ -198,7 +214,8 @@ impl Statement {
     // ...
 }
 ```
-</details>
+
+end[details]
 
 Don't forget to add a test in the [https://github.com/amber-lang/amber/tree/master/src/tests/validity](`validity`) folder and to add the new builtin to the list of the [reserved keywords](https://github.com/amber-lang/amber/blob/master/src/modules/variable/mod.rs#L16).
 
@@ -222,8 +239,7 @@ Tests will be executed without recompilation. Amber will load the scripts and ve
 
 Some tests require additional setup, such as those for `download` that needs Rust to load a web server. These functions require special tests written in Rust that we can find in `src/tests/stdlib.rs` file.
 
-<details>
-<summary>Let's write a simple test</summary>
+begin[details] Let's write a simple test
 
 ```rs
 #[test]
@@ -234,4 +250,5 @@ fn prints_hi() {
     test_amber!(code, "hi!");
 }
 ```
-</details>
+
+end[details]

--- a/src/components/Markdown/Markdown.module.css
+++ b/src/components/Markdown/Markdown.module.css
@@ -34,6 +34,19 @@
     color: var(--accent);
 }
 
+.markdown details {
+    background-color: var(--details-background);
+    padding: 1rem;
+    border-radius: 1rem;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+
+    & summary {
+        cursor: pointer;
+        font-size: 1.1rem;
+    }
+}
+
 .markdown .table-wrapper {
     width: calc(100% + 4rem);
     overflow-x: scroll;

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -7,6 +7,7 @@ import amber from './amber'
 import { useEffect } from 'react'
 import setSwipeToCopy from './swipeToCopy'
 import complexImageParser, { COMPLEX_IMAGE_RULE } from './complexImage'
+import { detailsBlockParser, DETAILS_BLOCK_RULE } from './detailsBlock'
 import { generateUrl, getLocation } from '@/utils/urls'
 import path from 'path'
 
@@ -18,7 +19,6 @@ const getHrefWithVersion = (href: string, currentUrl: string) => {
     const location = getLocation(params)
     return path.join('/', generateUrl(location.version, href))
 }
-
 
 const handleWarning = (text: string): string | null => {
     const warningText = 'WARNING:'
@@ -121,6 +121,7 @@ class MarkdownRenderer extends Renderer {
     }
 }
 
+Marked.setBlockRule(DETAILS_BLOCK_RULE, detailsBlockParser)
 Marked.setBlockRule(COMPLEX_IMAGE_RULE, complexImageParser)
 Marked.setOptions({
     renderer: new MarkdownRenderer(),

--- a/src/components/Markdown/detailsBlock.ts
+++ b/src/components/Markdown/detailsBlock.ts
@@ -1,0 +1,33 @@
+import { Marked } from '@ts-stack/markdown';
+
+export const DETAILS_BLOCK_RULE = /^\s*begin\[details\]\s+(.*?)\n([\s\S]*?)\n\s*end\[details\]\s*/;
+
+function dedent(str: string): string {
+    const lines = str.split('\n');
+    if (lines.length === 0) return str;
+
+    // Find minimum indentation of non-empty lines
+    let minIndent = Infinity;
+    for (const line of lines) {
+        if (line.trim().length === 0) continue;
+        const indent = line.search(/\S/);
+        if (indent !== -1 && indent < minIndent) {
+            minIndent = indent;
+        }
+    }
+
+    if (minIndent === Infinity) return str;
+
+    return lines.map(line => line.length >= minIndent ? line.slice(minIndent) : line).join('\n');
+}
+
+export function detailsBlockParser(execArr?: RegExpExecArray | string[] | null): string {
+    if (!execArr) return '';
+    const summary = execArr[1].trim();
+    const content = execArr[2];
+    
+    // Dedent the content to ensure markdown recognizes blocks correctly
+    const dedentedContent = dedent(content);
+    
+    return `<details><summary>${summary}</summary>${Marked.parse(dedentedContent)}</details>`;
+}

--- a/src/contexts/ThemeContext/config.ts
+++ b/src/contexts/ThemeContext/config.ts
@@ -54,6 +54,7 @@ const theme = {
         shadow: '#909090',
         shine: '#ffffff',
         border: '#ccc',
+        detailsBackground: '#E9EEEE',
         background: '#fff',
         ...codeTheme.light,
         ...constants
@@ -64,6 +65,7 @@ const theme = {
         shadow: '#5e473c',
         shine: '#552f2d',
         border: '#6b4a3e',
+        detailsBackground: '#221B19',
         background: '#191513',
         ...codeTheme.dark,
         ...constants


### PR DESCRIPTION
It's impossible to make `<details>` work a certain way, so I introduced this markdown syntax extension:
```md
begin[details] Title of the details bock

content inside of the details.

end[details]
```