### PR TITLE
ci: Exclude the nightly tags when filtering unseen commits

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -23,7 +23,7 @@ jobs:
           ref: staging
       - id: get-commits-step
         run: |
-          LATEST_TAG="$(git tag | grep -v nightly | tail --lines=1)"
+          LATEST_TAG="$(git tag --sort=version:refname | grep -v nightly | tail --lines=1)"
           echo latest tag is $LATEST_TAG
           SUBJECTS="$(git log "$LATEST_TAG..staging" --oneline --format=%s)"
           echo "--- Subjects ---"


### PR DESCRIPTION
The workflow tell us which commits are missing in the documentations. Currently, it is not so useful because `nightly` and `staging` are too close.

<img width="625" height="273" alt="image" src="https://github.com/user-attachments/assets/3c3b4aa5-d7a8-47f1-b68f-7b7cba9c0e4c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release tag identification by using version-aware sorting and excluding nightly tags so workflows select the correct latest release tag for computing commit ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->