### PR TITLE
Fix docs crashing

### DIFF
--- a/docs/nightly-alpha/getting_started/faq.md
+++ b/docs/nightly-alpha/getting_started/faq.md
@@ -1,5 +1,3 @@
-# FAQ
-
 ## Who is Amber for?
 
 Amber is aimed at developers who need the power of a modern programming language while staying within the ubiquitous Bash environment. It is especially useful for:

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -5,7 +5,7 @@ export type DocDescriptor = { index: number } & FlatDoc;
 
 export function getFlatTableOfContents(toc: TocSection[]): FlatDoc[] {
     return toc.map((section: TocSection) => {
-        const uniqueDocs = section.docs.filter(d => d.path !== section.path)
+        const uniqueDocs = (section.docs ?? []).filter(d => d.path !== section.path)
         const docsWithSection = uniqueDocs.map(d => ({ ...d, section: section.title }))
         return [{ ...section, section: section.title }, ...docsWithSection]
     }).flat() as FlatDoc[]

--- a/src/utils/docsServer.ts
+++ b/src/utils/docsServer.ts
@@ -4,7 +4,16 @@ import fs from 'fs/promises'
 import config from '@/../config.json'
 import path from 'path'
 
-export type TocSection = { path: string, title: string, docs: TocSection[], disableLevels?: number[] }
+export type TocDoc = {
+    path: string
+    title: string
+    disableLevels?: number[]
+    url?: string
+}
+
+export type TocSection = TocDoc & {
+    docs?: TocDoc[]
+}
 let cachedToc: Map<string, TocSection[]> = new Map()
 
 export async function getTableOfContents(version: string = config.defaultVersion): Promise<TocSection[]> {

--- a/src/views/Main/Main.tsx
+++ b/src/views/Main/Main.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export default async function Main({ location }: Props) {
     const toc = await getTableOfContents(location?.version);
-    const whatsNew = toc[0].docs.find(item => item.path === 'getting_started/whats_new')
+    const whatsNew = toc[0]?.docs?.find(item => item.path === 'getting_started/whats_new')
 
     return (
         <NavigationLayout hideSearch>


### PR DESCRIPTION
Summary
- Allow `getFlatTableOfContents` to treat undefined section docs as empty so nightly pages stop crashing.
- Mark `docs` optional in the TOC types and keep the `whats_new` lookup safe when the section or docs array is absent.
- Trim redundant header in `docs/nightly-alpha/getting_started/faq.md` to stay consistent with other entries.
Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential runtime errors when documentation sections or navigation data is missing.
  * Improved app stability by adding safety checks for missing table of contents data.

* **Documentation**
  * Refined FAQ section formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->