### PR TITLE
stuff for 0.6.0

### DIFF
--- a/docs/nightly-alpha/advanced_syntax/builtins.md
+++ b/docs/nightly-alpha/advanced_syntax/builtins.md
@@ -4,15 +4,37 @@ Similar to the standard library, they generate valid [Shellcheck](https://www.sh
 
 ## Cd
 
-Transpile to `cd` which changes the current directory, requires a `Text` parameter.
+Changes the current directory, requires a `Text` parameter.
 
 ```ab
-cd "/tmp"
+cd("/tmp")
 ```
+
+## Ls
+
+Returns an array of filenames in the specified directory. Accepts optional all and recursive boolean parameters. This is a failable expression — it returns [Text].
+
+```ab
+let files = trust ls("/tmp")
+
+let all_files = trust ls("/tmp", true, false)         // Include hidden files
+let recursive = trust ls("/tmp", false, true)         // List recursively
+let everything = trust ls("/tmp", true, true)         // Both
+```
+
+## Pwd
+
+Returns current working directory as `Text` value.
+
+```ab
+let dir = pwd()
+echo("Current directory: {dir}")
+```
+
 
 ## Echo
 
-Transpile to `echo` which prints text to the console, requires a `Text` parameter.
+Prints text to the console, requires a `Text` parameter.
 
 ```ab
 echo("Hello World!")
@@ -58,21 +80,48 @@ echo(len(lines))
 
 > WARNING: While embedded Bash commands like `$ cat foo.txt $` require a `trust` keyword or `failed` block, Amber does not currently support this for the `lines` builtin. If the file does not exist at runtime, the program will terminate midway, **potentially losing data stored only in variables**
 
+## Cp
+
+Copy files or directories from location to another. This builtin is failable.
+
+```
+cp("source.txt", "backup.txt")
+cp("-r", "src_dir", "dest_dir")  // Recursive copy
+```
+
 ## Mv
 
 If we need to move files we can use the `mv` builtin, requires two `Text` parameters.
 *Doesn't support the `mv` unix command parameters*.
 
 ```ab
-mv "/tmp/a" "/tmp/b"
+mv("/tmp/a", "/tmp/b")
 ```
 
 This builtin is `failable`, meaning we can handle errors like this:
 
 ```ab
-mv "/tmp/a" "/tmp/b" failed {
+mv("/tmp/a", "/tmp/b") failed {
     echo("Error")
 }
+```
+
+## Rm
+
+Removes files or directories from the filesystem. This is a failable builtin — use `failed` blocks or `trust` to handle errors.
+
+```ab
+rm("oldfile.txt")
+rm("-r", "/tmp/olddir")  // Recursive removal
+```
+
+## Touch
+
+Creates empty files or updates the modification timestamp of existing files. Accepts one or more file paths.
+
+```ab
+touch("newfile.txt")
+touch("/tmp/a.txt", "/tmp/b.txt")
 ```
 
 ## Nameof
@@ -88,3 +137,33 @@ trust $ {nameof variable}=12 $
 // Which is the same as declaring (but it is more readable in this way)
 let variable = 12
 ```
+
+## Sleep
+
+Pauses script execution for the specified number of seconds. Supports decimal values for sub-second delays.
+
+
+```ab
+sleep(5)   // Wait 5 seconds
+sleep(0.5) // Wait half a second
+```
+
+## Pid
+
+Returns the PID (Process ID) of the last background process executed. Useful for process management.
+
+
+```ab
+let last_pid = pid()
+echo("Last process: {last_pid}")
+```
+
+## Disown
+
+Removes background jobs using shell's job control. Can optionally accept a specific PID.
+
+```ab
+disown()      // Disown the most recent background job
+disown(1234)  // Disown a specific PID
+```
+

--- a/docs/nightly-alpha/advanced_syntax/builtins.md
+++ b/docs/nightly-alpha/advanced_syntax/builtins.md
@@ -86,7 +86,7 @@ Copy files or directories from location to another. This builtin is failable.
 
 ```
 cp("source.txt", "backup.txt")
-cp("src_dir", "dest_dir", "-r")  // Recursive copy
+cp("src_dir", "dest_dir", true)  // Recursive copy
 ```
 
 ## Mv

--- a/docs/nightly-alpha/advanced_syntax/builtins.md
+++ b/docs/nightly-alpha/advanced_syntax/builtins.md
@@ -86,7 +86,7 @@ Copy files or directories from location to another. This builtin is failable.
 
 ```
 cp("source.txt", "backup.txt")
-cp("-r", "src_dir", "dest_dir")  // Recursive copy
+cp("src_dir", "dest_dir", "-r")  // Recursive copy
 ```
 
 ## Mv
@@ -112,7 +112,7 @@ Removes files or directories from the filesystem. This is a failable builtin —
 
 ```ab
 rm("oldfile.txt")
-rm("-r", "/tmp/olddir")  // Recursive removal
+rm("/tmp/olddir", "-r")  // Recursive removal
 ```
 
 ## Touch
@@ -126,16 +126,21 @@ touch("/tmp/a.txt", "/tmp/b.txt")
 
 ## Nameof
 
-For more advanced commands, we might need the name of the variable in the compiled script. The `nameof` keyword provides this functionality.
+For more advanced commands, we might need the name of the variable or the function in the compiled script. The `nameof` keyword provides this functionality.
 
 For example, this allows us to perform operations like:
 
 ```ab
+fun my_function() {
+    echo("Hello world")
+}
 let variable = null
 
 trust $ {nameof variable}=12 $
 // Which is the same as declaring (but it is more readable in this way)
 let variable = 12
+// Call a function directly
+trust $ {nameof my_function} $
 ```
 
 ## Sleep

--- a/docs/nightly-alpha/advanced_syntax/builtins.md
+++ b/docs/nightly-alpha/advanced_syntax/builtins.md
@@ -112,7 +112,7 @@ Removes files or directories from the filesystem. This is a failable builtin —
 
 ```ab
 rm("oldfile.txt")
-rm("/tmp/olddir", "-r")  // Recursive removal
+rm("/tmp/olddir", true)  // Recursive removal
 ```
 
 ## Touch

--- a/docs/nightly-alpha/advanced_syntax/builtins.md
+++ b/docs/nightly-alpha/advanced_syntax/builtins.md
@@ -172,3 +172,54 @@ disown()      // Disown the most recent background job
 disown(1234)  // Disown a specific PID
 ```
 
+## Shellname
+
+Returns the name of the target shell at runtime. Useful for shell-specific code paths.
+
+```ab
+if shellname() == "bash" {
+    echo("Running in Bash")
+}
+```
+
+## Shellversion
+
+Returns the version of the target shell as an array of numbers.
+
+```ab
+if shellversion() > [3, 2, 0] {
+    echo("Bash version greater than 3.2.0")
+}
+```
+
+## Lock
+
+Creates a lock file to prevent concurrent execution. This is useful for scripts that should not run multiple times simultaneously.
+
+```ab
+lock("/tmp/myscript.lock") failed {
+    echo("Script is already running")
+    exit(1)
+}
+// Your script logic here
+```
+
+## Clear
+
+Clears the terminal screen.
+
+```ab
+clear()
+```
+
+## Await
+
+Waits for a specific background job to complete. Returns the exit status of the job.
+
+```ab
+let job = $ long_running_command &
+await(job) failed {
+    echo("Command failed")
+}
+```
+

--- a/docs/nightly-alpha/advanced_syntax/builtins.md
+++ b/docs/nightly-alpha/advanced_syntax/builtins.md
@@ -117,11 +117,10 @@ rm("/tmp/olddir", true)  // Recursive removal
 
 ## Touch
 
-Creates empty files or updates the modification timestamp of existing files. Accepts one or more file paths.
+Creates empty files or updates the modification timestamp of an existing file.
 
 ```ab
 touch("newfile.txt")
-touch("/tmp/a.txt", "/tmp/b.txt")
 ```
 
 ## Nameof
@@ -165,11 +164,10 @@ echo("Last process: {last_pid}")
 
 ## Disown
 
-Removes background jobs using shell's job control. Can optionally accept a specific PID.
+Removes background jobs using shell's job control.
 
 ```ab
 disown()      // Disown the most recent background job
-disown(1234)  // Disown a specific PID
 ```
 
 ## Shellname
@@ -194,10 +192,10 @@ if shellversion() > [3, 2, 0] {
 
 ## Lock
 
-Creates a lock file to prevent concurrent execution. This is useful for scripts that should not run multiple times simultaneously.
+Creates a lock file to prevent concurrent execution. This is useful for scripts that should not run multiple times simultaneously. Can be only used in the `main` or `test` block.
 
 ```ab
-lock("/tmp/myscript.lock") failed {
+lock() failed {
     echo("Script is already running")
     exit(1)
 }
@@ -217,8 +215,8 @@ clear()
 Waits for a specific background job to complete. Returns the exit status of the job.
 
 ```ab
-let job = $ long_running_command &
-await(job) failed {
+let job = $ long_running_command & $
+await(pid()) failed {
     echo("Command failed")
 }
 ```

--- a/docs/nightly-alpha/advanced_syntax/cross_shell.md
+++ b/docs/nightly-alpha/advanced_syntax/cross_shell.md
@@ -4,9 +4,9 @@ Since 0.6.0, Amber has introduced support for multiple shell targets:
 - bash 4.3+
 - bash 3.2+
 
-This gives developers the abilitiy to write one usable code for multiple shells without the need to consider all the differences between them all. 
+This gives developers the ability to write one usable code for multiple shells without the need to consider all the differences between them all. 
 
-While the syntax side is generated for specific target automatically, each shell has its own behaviour for the same commands, which still need to be processed invididually.
+While the syntax side is generated for specific target automatically, each shell has its own behaviour for the same commands, which still need to be processed individually.
 
 To implement code logic for individual shells, we have included `shellname()` and `shellversion()` builtins:
 

--- a/docs/nightly-alpha/advanced_syntax/cross_shell.md
+++ b/docs/nightly-alpha/advanced_syntax/cross_shell.md
@@ -1,0 +1,35 @@
+Since 0.6.0, Amber has introduced support for multiple shell targets:
+- zsh 5.8+ (only tested on 5.8 and above)
+- ksh 93u+m (only tested on 1.0.10)
+- bash 4.3+
+- bash 3.2+
+
+This gives developers the abilitiy to write one usable code for multiple shells without the need to consider all the differences between them all. 
+
+While the syntax side is generated for specific target automatically, each shell has its own behaviour for the same commands, which still need to be processed invididually.
+
+To implement code logic for individual shells, we have included `shellname()` and `shellversion()` builtins:
+
+```ab
+if {
+    shellname() == "bash" and shellversion() > [3,2,0] {
+        echo("using bash above 3.2")
+    }
+    shellname() == "ksh" {
+        echo("using ksh")
+    }
+    shellname() == "zsh" {
+        echo("using zsh")
+    }
+}
+```
+The builtins don't execute any other function and can be safely used multiple times without any performance losses.
+
+To build the script for specific target, use `--target` argument:
+
+```sh
+amber build script.ab --target bash # default (bash 4.3+)
+amber build script.ab --target bash-3.2
+amber build script.ab --target zsh
+amber build script.ab --target ksh
+```

--- a/docs/nightly-alpha/advanced_syntax/cross_shell.md
+++ b/docs/nightly-alpha/advanced_syntax/cross_shell.md
@@ -1,6 +1,6 @@
 Since 0.6.0, Amber has introduced support for multiple shell targets:
 - zsh 5.8+ (only tested on 5.8 and above)
-- ksh 93u+m (only tested on 1.0.10)
+- ksh 93u+m (only tested on 1.0.10); ksh is currently not being actively tested, some functions may not work properly
 - bash 4.3+
 - bash 3.2+
 

--- a/docs/nightly-alpha/basic_syntax/commands.md
+++ b/docs/nightly-alpha/basic_syntax/commands.md
@@ -146,5 +146,3 @@ suppress $ my_command $
 ```
 
 This is different from `silent` which suppresses both stdout and stderr.
-silent $ very loud command $
-```

--- a/docs/nightly-alpha/basic_syntax/commands.md
+++ b/docs/nightly-alpha/basic_syntax/commands.md
@@ -1,4 +1,4 @@
-{#silent #trust #unsafe #failed #succeeded #exited}
+{#silent #suppress #trust #unsafe #failed #succeeded #exited}
 
 The only way to access the bash shell is through Amber's commands. Commands can be used in the form of a statement or an expression.
 
@@ -134,5 +134,17 @@ This will be treated the same way Bash treats statements. If it fails, then carr
 You can easily silent given command. Here is an example usage:
 
 ```ab
+silent $ very loud command $
+```
+
+## Suppressing Stderr
+
+The `suppress` modifier suppresses only stderr output while allowing stdout to be captured. This is useful when you want to capture the command's output but don't want to see error messages:
+
+```ab
+suppress $ my_command $
+```
+
+This is different from `silent` which suppresses both stdout and stderr.
 silent $ very loud command $
 ```

--- a/docs/nightly-alpha/basic_syntax/functions.md
+++ b/docs/nightly-alpha/basic_syntax/functions.md
@@ -123,6 +123,24 @@ echo(groceries)
 
 The behavior of this keyword is pretty similar to `&` in other C-like programming languages.
 
+## Recursive Functions
+
+Amber supports recursive function calls, allowing a function to call itself. This is useful for algorithms like factorial, Fibonacci, or tree traversal.
+
+```ab
+fun factorial(n: Int): Int {
+    if n <= 1 {
+        return 1
+    }
+    return n * factorial(n - 1)
+}
+
+echo(factorial(5))
+// Outputs: 120
+```
+
+For recursive functions to work properly, you must specify the return type explicitly.
+
 ## Reserved Prefix
 
 The Amber compiler reserves all identifiers starting with double underscore `__` in addition to keywords like `let`, `if`, etc.

--- a/docs/nightly-alpha/basic_syntax/variables.md
+++ b/docs/nightly-alpha/basic_syntax/variables.md
@@ -39,3 +39,33 @@ Constant is a type of variable that cannot be modified.
 const sunrise = "east"
 sunrise = "west" // ERROR: Cannot reassign constant 'sunrise'
 ```
+
+## Public Variables
+
+Amber supports exporting variables to the compiled shell script, making them available to external scripts or the shell environment.
+
+### Public Constants
+
+Use `pub const` to export a constant value:
+
+```ab
+pub const VERSION = "1.0"
+pub const APP_NAME = "MyApp"
+```
+
+These variables will be accessible in the compiled script and can be sourced by other scripts.
+
+### Public Mutable Variables
+
+Use `pub let` with `#[allow_public_mutable]` attribute to export mutable variables:
+
+```ab
+#[allow_public_mutable]
+pub let counter = 0
+
+fun increment() {
+    counter += 1
+}
+```
+
+> NOTE: Mutable public exports require explicit opt-in via the `#[allow_public_mutable]` attribute for safety reasons.

--- a/docs/nightly-alpha/basic_syntax/variables.md
+++ b/docs/nightly-alpha/basic_syntax/variables.md
@@ -20,17 +20,6 @@ echo(name) // Outputs: "Rob"
 
 > WARNING: The Amber compiler reserves all identifiers starting with double underscore `__` in addition to keywords like `let`, `if`, etc.
 
-## Overshadowing
-
-Variable declarations in Amber can be overshadowed, allowing the redeclaration of an existing variable with a different data type within a specific scope if necessary. Here’s an example:
-
-```ab
-// `result` is a `Num`
-let result = 123
-// `result` is a `Text`
-let result = "Hello my friend"
-```
-
 # Constant {#const}
 
 Constant is a type of variable that cannot be modified.

--- a/docs/nightly-alpha/basic_syntax/variables.md
+++ b/docs/nightly-alpha/basic_syntax/variables.md
@@ -58,3 +58,7 @@ fun increment() {
 ```
 
 > NOTE: Mutable public exports require explicit opt-in via the `#[allow_public_mutable]` attribute for safety reasons.
+
+### Variable redeclaration
+
+Variables cannot be redeclared with another type or as a function within the same scope. This will result in a compiler error.

--- a/docs/nightly-alpha/getting_started/getting_started.md
+++ b/docs/nightly-alpha/getting_started/getting_started.md
@@ -7,7 +7,7 @@ echo("Hello world!")
 
 ## What is Amber?
 
-Amber is a programming language compiled into Bash Script. It was designed with a modern syntax, safety features, type safety and practical functionalities that Bash could not offer. The subsequent section will demonstrate how Amber embodies these characteristics.
+Amber is a programming language compiled into Shell Script. It was designed with a modern syntax, safety features, type safety and practical functionalities that normal shells could not offer. The subsequent section will demonstrate how Amber embodies these characteristics.
 
 ### Modern Syntax
 
@@ -15,7 +15,7 @@ Amber is designed based on the ECMA script syntax. The goal was to create a synt
 
 ### Safety Features
 
-When Bash command fails - it carries on with the code execution as if nothing has happened. This could lead to some serious problems and side effects that are irreversible.
+When shell command fails - it carries on with the code execution as if nothing has happened. This could lead to some serious problems and side effects that are irreversible.
 
 We dislike this behavior. This is why Amber will not compile if edge cases aren't handled - whether that involves displaying an error message to the user or failing silently.
 
@@ -29,13 +29,15 @@ Amber supports things that are essential to developer like floating point arithm
 
 ### Supported Environments
 
-Amber's compiled Bash scripts are actively tested across a range of environments.
+Amber's compiled shell scripts are actively tested across a range of environments.
 
 | Environment       | Version Range | Status               | Notes                                                              |
 |-------------------|---------------|----------------------|--------------------------------------------------------------------|
-| **Bash (Linux) GNU**  | 3.2 - 5.3     | Under Testing | All versions within this range are tested using [tianon/docker-bash](https://github.com/tianon/docker-bash). |
-| **Bash (macOS)**  | 3.2           | Under Testing | Verified through GitHub Actions `macos-latest` environments.       |
-| **Bash (Linux) Busy Box**           | Latest           | Under Testing | Busy box environment. As of right now latest is 5.3 |
+| **Bash (Linux) GNU**      | 3.2 - 5.3 | Under Testing    | All versions within this range are tested using [tianon/docker-bash](https://github.com/tianon/docker-bash). |
+| **Bash (macOS)**          | 3.2       | Under Testing     | Verified through GitHub Actions `macos-latest` environments.       |
+| **Bash (Linux) Busy Box** | Latest    | Under Testing     | Busy box environment. As of right now latest is 5.3 |
+| **ZSH (Linux and macOS)** | 5.8 - 5.9 | Under Testing     | Verified through GitHub Actions environment. |
+| **KSH93 (Linux)**         | 1.0.10    | Not Under Testing | The functionality is only tested locally and individually. |
 
 ---
 

--- a/docs/nightly-alpha/getting_started/installation.md
+++ b/docs/nightly-alpha/getting_started/installation.md
@@ -65,11 +65,11 @@ bin update
 
 - **System-wide**
 ```bash
-bash <(curl -sL "https://github.com/amber-lang/amber/releases/download/0.5.1-alpha/install.sh")
+bash <(curl -sL "https://github.com/amber-lang/amber/releases/download/0.6.0-alpha/install.sh")
 ```
 - **Local-user**
 ```bash
-bash -- <(curl -sL "https://github.com/amber-lang/amber/releases/download/0.5.1-alpha/install.sh") --user
+bash -- <(curl -sL "https://github.com/amber-lang/amber/releases/download/0.6.0-alpha/install.sh") --user
 ```
 
 - **Available versions with package managers**
@@ -155,5 +155,5 @@ If these tools are available on your system, they will be executed at the end of
 If you have installed it via the script installation option, simply run the following code snippet.
 
 ```sh
-bash -- <(curl -sL "https://github.com/amber-lang/amber/releases/download/0.5.1-alpha/uninstall.sh")
+bash -- <(curl -sL "https://github.com/amber-lang/amber/releases/download/0.6.0-alpha/uninstall.sh")
 ```

--- a/docs/nightly-alpha/getting_started/migration_guide.md
+++ b/docs/nightly-alpha/getting_started/migration_guide.md
@@ -1,197 +1,23 @@
-This guide provides a step-by-step walkthrough for migrating code from 0.4.0-alpha to 0.5.0-alpha. The current version introduces several breaking changes. This document outlines the modifications, explains how to adapt your code to maintain the same behavior, and highlights updated features. In this guide we will cover two main categories of changes:
+This guide provides a step-by-step walkthrough for migrating code from 0.5.0-alpha to 0.6.0-alpha. The current version introduces a single breaking change for the code.
 1. **Language Features**: Changes and updates to the core language syntax and semantics.
-2. **Standard Library Updates**: Modifications to existing standard library functions and their usage.
 
 Follow along to ensure a smooth transition to the new version. Let’s get started!
 
-# New integer `Int` data type <!-- #712 #752 -->
+# Changes to builtin syntax
+Builtins now use function-like syntax for code readability and easier parsing:
 
-Previously, Amber supported only the `Num` type. This release introduces `Int`, which maps to Bash’s native integer arithmetic. To support this, we’ve updated parts of the language syntax.
+```diff
+- echo "Hello world"
++ echo("Hello world")
 
-## Array subscript
-
-Expression in the subscript can only be of type `Int`.
-
-```ab
-// Before
-arr[12.0] // Ok; although fails
-
-// After
-arr[12.0] // Error: array subscript can only be an integer
+- cp "source.txt" "target.txt"
++ cp("source.txt", "target.txt")
 ```
 
-## Range
-
-Expressions in range operator can only be of type `Int`.
-
-```ab
-// Before
-10.0..15.0 // OK; although fails
-
-// After
-10.0..15.0 // Error: range can only be applied on integers
-```
-
-## Iterator
-
-Iterator variable in for-loop is now of type `Int`.
+# New public variables
+If you have previously used workarounds to export your variables, you can now remove them and use `pub` modifier:
 
 ```ab
-// Before
-for i, item in items {} // `i` is a `Num`
-
-// After
-for i, item in items {} // `i` is an `Int`
-```
-
-## Exit
-
-Exit builtin now accepts only expressions of type `Int`.
-
-```ab
-// Before
-exit 2.0 // Ok; although fails
-
-// After
-exit 2.0 // Error: exit accepts only `Int` type
-```
-
-## Status
-
-The `status` builtin now returns a value of type `Int`.
-
-```ab
-// Before
-status // Returns `Num` value
-
-// After
-status // Returns `Int` value
-```
-
-## Len
-
-The `len` builtin now returns a value of type `Int`.
-
-```ab
-// Before
-len(text) // Returns `Num` value
-
-// After
-len(text) // Returns `Int` value
-```
-
-# Text to Bool Casting Warning <!-- #719 #831 -->
-
-Casting `Text` to any values including `Bool` and `Int`, now issues an "absurd cast" warning. While not an error, it indicates a potential logical issue and encourages explicit conversion for clarity.
-
-```ab
-// Before
-echo "true" as Bool then 1 else 0 // OK
-
-// After
-echo("true" as Bool then 1 else 0) // Warning: Absurd cast
-```
-
-# Escaping Changes
-
-## String Literal Escaping Changes <!-- #594 -->
-
-A bug related to the escaping of `$` sequences within string literals has been fixed. Previously, `"\$variable"` would incorrectly interpolate the value of `variable` instead of treating `$` as a literal character. If your code inadvertently relied on the previous buggy behavior where `\$` within a string literal was interpolated, you will now observe the correct behavior where `\$` is treated as a literal dollar sign. You may need to adjust your string literals if you intended interpolation in such cases.
-
-```ab
-// Before
-let var = 45
-echo "\$var" // Output: 45
-
-// After
-let var = 45
-echo("\$var") // Output: \$var
-```
-
-## Command String Escaping Changes <!-- #772 -->
-
-The internal handling of text within commands has been refactored, leading to a breaking change in how double quotes (`"`) should be escaped within command strings. Previously, `"` might have been escaped with `\"` in some contexts, but this is no longer the correct behavior.
-
-Double quotes (`"`) should *not* be escaped with a backslash (`\`) when used within command strings. The parser now handles this automatically. If your code contains command strings where double quotes are escaped (e.g., `$ echo \"hello\" $`), you must remove the backslash.
-
-```ab
-// Before (will now cause an error or incorrect behavior)
-trust $ printf \"Amber\" $ // Incorrect: will now be interpreted as a literal backslash followed by a double quote
-
-// After (correct behavior)
-trust $ printf "Amber" $ // Correct: the double quote is handled by the parser
-```
-
-# Standard Library Updates
-
-## Redesigned `std/date`
-
-The standard library’s Date module has been completely overhauled. We improved how its functions compose, removed obsolete ones, and repurposed others. The complete list of changes is below.
-
-| Old Name | New Name | Description |
-|:--|:--|:--|
-| `date_posix` | `date_from_posix` | Converts textual representation in a default `YYYY-MM-DD HH:MM:SS` format to [unix epoch time](https://en.wikipedia.org/wiki/Unix_time) |
-| *new* | `date_format_posix` | Converts [unix epoch time](https://en.wikipedia.org/wiki/Unix_time) to a textual representation. |
-| `date_add` | `date_add` | Adds time to passed date. |
-| *new* | `date_sub` | Subtracts time to passed date. |
-| *removed* | `date_compare` | Compares two dates and returns value of a sign function. |
-
-## Regex Functions Compatibility Changes <!-- #717 -->
-
-To improve cross-platform compatibility, especially with macOS and BusyBox environments, the standard library functions `match_regex()` and `replace_regex()` no longer support certain GNU Sed-specific regular expression features. If your existing code relies on these GNU Sed-specific features within `match_regex()` or `replace_regex()`, you will need to update your regular expressions to use POSIX-compliant alternatives. For example, instead of `\b`, you might use `[[:<:]]` and `[[:>:]]` for word boundaries, or ensure you are using ERE for alternation (`|`).
-
-The following regular expression features are no longer supported within `match_regex()` and `replace_regex()`:
-*   `\b` (word boundary) in both Extended Regular Expressions (ERE) and Basic Regular Expressions (BRE).
-*   `|` (alternation) in Basic Regular Expressions (BRE).
-
-## Function Renaming <!-- #768 -->
-
-The standard library function `parse_number` has been renamed to `parse_num` to align with the new `Int` data type and improve clarity. If your code directly calls `parse_number`, you will need to update these calls to `parse_num`.
-
-```ab
-// Before
-const num_val = trust parse_number("123.45")
-
-// After
-const num_val = trust parse_num("123.45")
-```
-
-## Functions Now Failable <!-- #791 -->
-
-Several standard library functions that previously returned a `Bool` to indicate success or failure have been updated to be failable functions. This change aligns with Amber's failable paradigm, providing a more consistent and robust error handling mechanism. These functions no longer return a `Bool`. Instead, they will either succeed or fail, triggering the failable mechanism (e.g., propagating failure with `?` or being caught by a `failed` block).
-
-**Affected Functions:**
-- `std/fs::symlink_create`
-- `std/fs::dir_create`
-- `std/fs::file_chmod`
-- `std/fs::file_chown`
-- `std/net::file_download`
-
-```ab
-// Before
-if dir_create("my_directory") {
-    echo "Directory created successfully."
-} else {
-    echo "Failed to create directory."
-}
-
-// After
-dir_create("my_directory") exited(code) {
-    if code == 0:
-        echo("Directory created successfully.")
-    else:
-        echo("Failed to create directory.")
-}
-```
-
-## Removed `env_const_get` Function
-
-The `env_const_get` function has been removed from `std/env`. Use `env_var_get` instead, which provides the same functionality.
-
-```ab
-// Before
-env_const_get("VAR")
-
-// After
-env_var_get("VAR")
+pub const VERSION = "1.0"
+pub const WORKING_DIR = "."
 ```

--- a/docs/nightly-alpha/getting_started/migration_guide.md
+++ b/docs/nightly-alpha/getting_started/migration_guide.md
@@ -1,4 +1,4 @@
-This guide provides a step-by-step walkthrough for migrating code from 0.5.0-alpha to 0.6.0-alpha. The current version introduces a single breaking change for the code.
+This guide provides a step-by-step walkthrough for migrating code from 0.5.0-alpha to 0.6.0-alpha. The current version introduces a single breaking change.
 1. **Language Features**: Changes and updates to the core language syntax and semantics.
 
 Follow along to ensure a smooth transition to the new version. Let’s get started!

--- a/docs/nightly-alpha/getting_started/migration_guide.md
+++ b/docs/nightly-alpha/getting_started/migration_guide.md
@@ -21,3 +21,30 @@ If you have previously used workarounds to export your variables, you can now re
 pub const VERSION = "1.0"
 pub const WORKING_DIR = "."
 ```
+
+For mutable public variables, you now need to explicitly opt-in with the `#[allow_public_mutable]` attribute:
+
+```ab
+#[allow_public_mutable]
+pub let counter = 0
+```
+
+# Stricter failure handling
+
+The compiler now has stricter rules around failure handling:
+
+- Failable return types must use `?`
+- Infallible functions must not use `?`
+- Invalid combinations of `trust` and `?` are now diagnosed clearly
+
+```ab
+// Now an error - infallible function cannot use ?
+fun myFunc(): Int {
+    return something()?  // Error
+}
+
+// Correct usage
+fun myFunc(): Int? {
+    return something()?  // Valid - returns Int?
+}
+```

--- a/docs/nightly-alpha/getting_started/migration_guide.md
+++ b/docs/nightly-alpha/getting_started/migration_guide.md
@@ -1,4 +1,4 @@
-This guide provides a step-by-step walkthrough for migrating code from 0.5.0-alpha to 0.6.0-alpha. The current version introduces a single breaking change.
+This guide provides a step-by-step walkthrough for migrating code from 0.5.0-alpha to 0.6.0-alpha. The current version introduces breaking changes.
 1. **Language Features**: Changes and updates to the core language syntax and semantics.
 
 Follow along to ensure a smooth transition to the new version. Let’s get started!

--- a/docs/nightly-alpha/getting_started/migration_guide.md
+++ b/docs/nightly-alpha/getting_started/migration_guide.md
@@ -1,5 +1,4 @@
-This guide provides a step-by-step walkthrough for migrating code from 0.5.0-alpha to 0.6.0-alpha. The current version introduces breaking changes.
-1. **Language Features**: Changes and updates to the core language syntax and semantics.
+This guide provides a step-by-step walkthrough for migrating code from 0.5.0-alpha to 0.6.0-alpha. The current version introduces breaking changes related to the core language syntax and semantics.
 
 Follow along to ensure a smooth transition to the new version. Let’s get started!
 
@@ -47,4 +46,13 @@ fun myFunc(): Int {
 fun myFunc(): Int? {
     return something()?  // Valid - returns Int?
 }
+```
+
+# Removed variable overshadowing
+
+Redecleration of the variable of function with the same name will now result in an error:
+
+```ab
+    let var = "test"
+    let var = 12 // Error
 ```

--- a/docs/nightly-alpha/getting_started/usage.md
+++ b/docs/nightly-alpha/getting_started/usage.md
@@ -116,6 +116,19 @@ Furthermore, Amber adds a _shebang_ at the top of the compiled script. This enab
 $ ./output.sh
 ```
 
+### Compiling for different targets
+
+Since 0.6.0, Amber adds support for multiple shell targets:
+
+```sh
+amber build script.ab --target bash # default (bash 4.3+)
+amber build script.ab --target bash-3.2
+amber build script.ab --target zsh
+amber build script.ab --target ksh
+```
+
+For more information, visit [Cross-shell support](advanced_syntax/cross_shell) guide.
+
 ## Testing
 
 Amber comes with a built-in test runner. You can define named test blocks in your code and execute them using the `amber test` command.

--- a/docs/nightly-alpha/getting_started/usage.md
+++ b/docs/nightly-alpha/getting_started/usage.md
@@ -4,7 +4,7 @@ The Amber CLI can be used as a runtime or as a compiler.
 
 The Amber CLI syntax uses subcommands, like the Git CLI:
 
-*This output is generated from the 0.5.2-alpha version.*
+*This output is generated from the 0.6.0-alpha version.*
 ```
 Usage: amber [OPTIONS] [INPUT] [ARGS]... [COMMAND]
 
@@ -27,6 +27,7 @@ Options:
                            Available postprocessors: 'bshchk'
                            To select multiple, pass multiple times with different values
                            Argument also supports a wildcard match, like "*" or "b*chk"
+      --target <TARGET>    Code generation target shell
   -h, --help               Print help
   -V, --version            Print version
 ```

--- a/docs/nightly-alpha/index.json
+++ b/docs/nightly-alpha/index.json
@@ -89,6 +89,10 @@
                     "title": "Type Condition"
                 },
                 {
+                    "path": "advanced_syntax/cross_shell",
+                    "title": "Cross-shell support"
+                },
+                {
                     "path": "advanced_syntax/compiler_flags",
                     "title": "Compiler Flags"
                 }


### PR DESCRIPTION
includes initial preparation for v0.6.0:
- added page about cross-shell support
- updated `Getting Started` to be more generic, added all environments
- updated links in `Installation` to match the version
- updated `Migration Guide`
- updated `Builtins`
- updated `Usage` with new target option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded builtin docs: added ls, pwd, cp, rm, touch, sleep (decimal seconds), pid, disown; examples now use function-call syntax and nameof examples include functions.
  * Added cross-shell guidance and a new --target CLI option for bash, bash-3.2, zsh, and ksh; included cross-shell examples.
  * Updated supported environments to include ZSH 5.8–5.9 and KSH93 1.0.10.
  * Revised migration guide and updated install/uninstall scripts to 0.6.0-alpha; added index entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->