### PR TITLE
fix(menu): support for url

### DIFF
--- a/docs/0.6.0-alpha/index.json
+++ b/docs/0.6.0-alpha/index.json
@@ -181,6 +181,11 @@
                 {
                     "path": "by_example/lsp_installer",
                     "title": "LSP Installer"
+                },
+                {
+                    "path": "by_example/awesome_amber",
+                    "title": "Awesome Amber",
+                    "url": "https://github.com/amber-lang/awesome-amberlang"
                 }
             ]
         },

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -62,26 +62,48 @@ export default function SideBar({ headers, docDesc, toc = [], isFixed = false }:
                 {headers.length > 0 && <div className={style.spacer}/>}
                 <Island label="Table of contents">
                     <div className={[style.links, !headers.length && style.toc].join(' ')} ref={tocRef}>
-                        {toc.map(({ path, title, docs }) => (
+                        {toc.map(({ path, title, docs, url }) => (
                                 <React.Fragment key={path}>
-                                    <PrefetchLink href={`/${generateUrl(version, path)}`} key={path} docPath={`${version}/${path}`}>
-                                        <Text block>
-                                            <div className={style.indent} {...{ indent: "0", path }}>{title}</div>
-                                        </Text>
-                                    </PrefetchLink>
-                                    {docs && docs.map(({ path, title }, index) => (
+                                    {url ? (
+                                        <a href={url} target="_blank" rel="noopener noreferrer">
+                                            <Text block>
+                                                <div className={style.indent} {...{ indent: "0", path }}>{title}</div>
+                                            </Text>
+                                        </a>
+                                    ) : (
+                                        <PrefetchLink href={`/${generateUrl(version, path)}`} key={path} docPath={`${version}/${path}`}>
+                                            <Text block>
+                                                <div className={style.indent} {...{ indent: "0", path }}>{title}</div>
+                                            </Text>
+                                        </PrefetchLink>
+                                    )}
+                                    {docs && docs.map(({ path, title, url: docUrl }, index) => (
                                         <React.Fragment key={path}>
-                                            <PrefetchLink href={`/${generateUrl(version, path)}`} docPath={`${version}/${path}`}>
-                                                <Text block>
-                                                    <div
-                                                        className={style.indent}
-                                                        style={{ '--distance': '0' } as any}
-                                                        {...{ indent: 1, path, relation: index === 0 ? 'child' : 'sibling' }}
-                                                    >
-                                                        {title}
-                                                    </div>
-                                                </Text>
-                                            </PrefetchLink>
+                                            {docUrl ? (
+                                                <a href={docUrl} target="_blank" rel="noopener noreferrer" key={path}>
+                                                    <Text block>
+                                                        <div
+                                                            className={style.indent}
+                                                            style={{ '--distance': '0' } as any}
+                                                            {...{ indent: 1, path, relation: index === 0 ? 'child' : 'sibling' }}
+                                                        >
+                                                            {title}
+                                                        </div>
+                                                    </Text>
+                                                </a>
+                                            ) : (
+                                                <PrefetchLink href={`/${generateUrl(version, path)}`} docPath={`${version}/${path}`}>
+                                                    <Text block>
+                                                        <div
+                                                            className={style.indent}
+                                                            style={{ '--distance': '0' } as any}
+                                                            {...{ indent: 1, path, relation: index === 0 ? 'child' : 'sibling' }}
+                                                        >
+                                                            {title}
+                                                        </div>
+                                                    </Text>
+                                                </PrefetchLink>
+                                            )}
                                         </React.Fragment>
                                     ))}
                                 </React.Fragment>

--- a/src/utils/docsServer.ts
+++ b/src/utils/docsServer.ts
@@ -4,8 +4,8 @@ import fs from 'fs/promises'
 import config from '@/../config.json'
 import path from 'path'
 
-export type TocSection = { path: string, title: string, docs: TocSection[], disableLevels?: number[] }
-type TocSectionInput = { path: string, title: string, docs?: TocSectionInput[], disableLevels?: number[] }
+export type TocSection = { path: string, title: string, docs: TocSection[], disableLevels?: number[], url?: string }
+type TocSectionInput = { path: string, title: string, docs?: TocSectionInput[], disableLevels?: number[], url?: string }
 let cachedToc: Map<string, TocSection[]> = new Map()
 
 function normalizeToc(sections: TocSectionInput[] = []): TocSection[] {
@@ -13,6 +13,7 @@ function normalizeToc(sections: TocSectionInput[] = []): TocSection[] {
         path: section.path,
         title: section.title,
         disableLevels: section.disableLevels,
+        url: section.url,
         docs: normalizeToc(section.docs ?? [])
     }))
 }


### PR DESCRIPTION
Fix: #191 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table of contents now supports external links. Sections and documentation items can be configured with URLs that open in new browser tabs, providing an alternative to internal navigation. This enhancement adds flexibility while preserving backward compatibility with all existing internal navigation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->