### PR TITLE
Add Homebrew installation instructions

### DIFF
--- a/docs/0.5.1-alpha/getting_started/installation.md
+++ b/docs/0.5.1-alpha/getting_started/installation.md
@@ -25,6 +25,14 @@ Make sure that the operating system meets the following prerequisites
 
 > DETAILS: You should always update the system before you install a package in a rolling release distro, such as **Arch** and **Tumbleweed.**. Always reboot after an update of the kernel, init system, and similar software as well. 
 
+## Installation with Homebrew
+
+Running this snippet will install latest stable version.
+
+```sh
+brew install amber-lang/amber/amber-lang
+```
+
 ## Installation via *bin*, the binary package manager
 
 **Install bin itself**:

--- a/docs/0.6.0-alpha/getting_started/installation.md
+++ b/docs/0.6.0-alpha/getting_started/installation.md
@@ -25,6 +25,14 @@ Make sure that the operating system meets the following prerequisites
 
 > DETAILS: You should always update the system before you install a package in a rolling release distro, such as **Arch** and **Tumbleweed.**  Always reboot after an update of the kernel, init system, and similar software as well. 
 
+## Installation with Homebrew
+
+Running this snippet will install latest stable version.
+
+```sh
+brew install amber-lang/amber/amber-lang
+```
+
 ## Installation via `bin`, the binary package manager
 
 **Install bin itself**:

--- a/docs/nightly-alpha/getting_started/installation.md
+++ b/docs/nightly-alpha/getting_started/installation.md
@@ -25,6 +25,14 @@ Make sure that the operating system meets the following prerequisites
 
 > DETAILS: You should always update the system before you install a package in a rolling release distro, such as **Arch** and **Tumbleweed.**  Always reboot after an update of the kernel, init system, and similar software as well. 
 
+## Installation with Homebrew
+
+Running this snippet will install latest stable version.
+
+```sh
+brew install amber-lang/amber/amber-lang
+```
+
 ## Installation via `bin`, the binary package manager
 
 **Install bin itself**:


### PR DESCRIPTION
Quick fix to add missing brew installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew installation instructions to the installation guide, enabling users to install Amber via package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->