### PR TITLE
chore(typo): fix documentation

### DIFF
--- a/docs/0.6.0-alpha/getting_started/whats_new.md
+++ b/docs/0.6.0-alpha/getting_started/whats_new.md
@@ -37,7 +37,7 @@ Added control-flow-aware validation for ternary expressions and related typing, 
 
 ```ab
 // The compiler correctly types this based on condition logic
-let result = value is Num then 42 else "Hello World"
+let result = value is Num then "42" else "Hello World"
 ```
 
 # Union Types


### PR DESCRIPTION
Hello there ! 

I corrected the example in the ternary expressions section to ensure proper typing.

If you run the code as it is you got this error:

"Ternary operation must evaluate to one type, got Int and Text"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ternary control-flow validation example to accurately demonstrate conditional typing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->