### PR TITLE
fix(docs): remove unused imports in the backup rotator example

### DIFF
--- a/docs/0.5.1-alpha/by_example/backup_rotator.md
+++ b/docs/0.5.1-alpha/by_example/backup_rotator.md
@@ -1,7 +1,7 @@
 This script demonstrates an automated backup rotation system that keeps only the most recent backups while deleting older ones.
 
 ```ab
-import { dir_exists, dir_create, file_exists } from "std/fs"
+import { dir_exists, dir_create } from "std/fs"
 import { parse_int, trim } from "std/text"
 import { date_now, date_format_posix } from "std/date"
 

--- a/docs/0.6.0-alpha/by_example/backup_rotator.md
+++ b/docs/0.6.0-alpha/by_example/backup_rotator.md
@@ -1,7 +1,7 @@
 This script demonstrates an automated backup rotation system that keeps only the most recent backups while deleting older ones.
 
 ```ab
-import { dir_exists, dir_create, file_exists } from "std/fs"
+import { dir_exists, dir_create } from "std/fs"
 import { parse_int, trim } from "std/text"
 import { date_now, date_format_posix } from "std/date"
 

--- a/docs/nightly-alpha/by_example/backup_rotator.md
+++ b/docs/nightly-alpha/by_example/backup_rotator.md
@@ -1,7 +1,7 @@
 This script demonstrates an automated backup rotation system that keeps only the most recent backups while deleting older ones.
 
 ```ab
-import { dir_exists, dir_create, file_exists } from "std/fs"
+import { dir_exists, dir_create } from "std/fs"
 import { parse_int, trim } from "std/text"
 import { date_now, date_format_posix } from "std/date"
 


### PR DESCRIPTION
I was checking out the language and the examples and noticed that file_exists was unused.

In this PR, it has been removed from every version of the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backup rotation examples across supported documentation versions.
  * Removed an obsolete import from the examples to keep them clean and ready to use.
  * Backup creation, validation, directory setup, and rotation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->