### PR TITLE
fix(docs): add parentheses to exit calls in ubuntu updater

### DIFF
--- a/docs/0.6.0-alpha/by_example/ubuntu_updater.md
+++ b/docs/0.6.0-alpha/by_example/ubuntu_updater.md
@@ -15,7 +15,7 @@ main {
     // case.
     trust $ iwgetid -r | grep -E '(OEBB|WESTlan)' $ succeeded {
         echo("Skipping updates because of slow Wifi")
-        exit 0
+        exit(0)
     }
 
     $ export DEBIAN_FRONTEND=noninteractive $?

--- a/docs/nightly-alpha/by_example/ubuntu_updater.md
+++ b/docs/nightly-alpha/by_example/ubuntu_updater.md
@@ -15,7 +15,7 @@ main {
     // case.
     trust $ iwgetid -r | grep -E '(OEBB|WESTlan)' $ succeeded {
         echo("Skipping updates because of slow Wifi")
-        exit 0
+        exit(0)
     }
 
     $ export DEBIAN_FRONTEND=noninteractive $?


### PR DESCRIPTION
This fixes two missed instances of exit calls with missing parentheses.

Ref: https://github.com/amber-lang/amber-docs/pull/156#pullrequestreview-3585156666