### PR TITLE
fix(docs): failure handling in the ubuntu update example

### DIFF
--- a/docs/0.6.0-alpha/by_example/ubuntu_updater.md
+++ b/docs/0.6.0-alpha/by_example/ubuntu_updater.md
@@ -13,7 +13,7 @@ main {
 
     // Internet is slow on Austrian trains. Check the Wifi SSID and stop in that
     // case.
-    trust $ iwgetid -r | grep -E '(OEBB|WESTlan)' $ succeeded {
+    $ iwgetid -r | grep -E '(OEBB|WESTlan)' $ succeeded {
         echo("Skipping updates because of slow Wifi")
         exit(0)
     }

--- a/docs/0.6.0-alpha/by_example/ubuntu_updater.md
+++ b/docs/0.6.0-alpha/by_example/ubuntu_updater.md
@@ -9,7 +9,7 @@ main {
     // Print output and log it at the same time.
     $ exec > >(tee -a /var/log/autoapt.log) 2>&1 $?
     // Log the current date so that we can check when any failed runs happened.
-    echo(date_format_posix(date_now()))
+    echo(trust date_format_posix(date_now()))
 
     // Internet is slow on Austrian trains. Check the Wifi SSID and stop in that
     // case.

--- a/docs/nightly-alpha/by_example/ubuntu_updater.md
+++ b/docs/nightly-alpha/by_example/ubuntu_updater.md
@@ -13,7 +13,7 @@ main {
 
     // Internet is slow on Austrian trains. Check the Wifi SSID and stop in that
     // case.
-    trust $ iwgetid -r | grep -E '(OEBB|WESTlan)' $ succeeded {
+    $ iwgetid -r | grep -E '(OEBB|WESTlan)' $ succeeded {
         echo("Skipping updates because of slow Wifi")
         exit(0)
     }

--- a/docs/nightly-alpha/by_example/ubuntu_updater.md
+++ b/docs/nightly-alpha/by_example/ubuntu_updater.md
@@ -9,7 +9,7 @@ main {
     // Print output and log it at the same time.
     $ exec > >(tee -a /var/log/autoapt.log) 2>&1 $?
     // Log the current date so that we can check when any failed runs happened.
-    echo(date_format_posix(date_now()))
+    echo(trust date_format_posix(date_now()))
 
     // Internet is slow on Austrian trains. Check the Wifi SSID and stop in that
     // case.


### PR DESCRIPTION
This adds a `trust` keyword to `date_format_posix` and removes a redundant (and in this case disallowed) `trust` keyword

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ubuntu updater examples to handle date output trust explicitly.
  * Clarified Wi‑Fi connectivity checks by applying trust to the command’s success condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->