### PR TITLE
Implement fallback for ZIP extraction errors

### DIFF
--- a/sync-stdlib-doc.ab
+++ b/sync-stdlib-doc.ab
@@ -121,6 +121,16 @@ fun check_system_dependencies(): Bool {
     return true
 }
 
+fun file_extract_fallback(tmp_zip: Text, tmp_dir: Text): Bool {
+    silent $ unzip -q "{tmp_zip}" -d "{tmp_dir}" $ failed (file_extract_error) {
+        echo("❌ Error: Extracting ZIP file: {file_extract_error}")
+
+        return false
+    }
+
+    return true
+}
+
 fun fetch_source_code(): Bool {
     echo("⬇️  Downloading source code from {REPO_ARCHIVE_URL}...")
 
@@ -133,6 +143,11 @@ fun fetch_source_code(): Bool {
     echo("⚙️  Extracting files...")
 
     silent file_extract(TMP_ZIP, TMP_DIR) failed (file_extract_error) {
+        if file_extract_error == 3 {
+            // 3 (magic number) = Error: Unsupported file type (Amber)
+            return file_extract_fallback(TMP_ZIP, TMP_DIR)
+        }
+
         echo("❌ Error: Extracting ZIP file: {file_extract_error}")
 
         return false


### PR DESCRIPTION
Add fallback function for extracting ZIP files in case of unsupported file types.

Temporary change until the PR [fix(stdlib): #1142 and #1140 - #1143](https://github.com/amber-lang/amber/pull/1143/changes#diff-cdcb43d2d166dd81d077bb17cb5ddbf3a0fab19b343610e415ed45c576577f4cR234) is merged into the `main` branch of Amber.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a fallback for extracting archives that aren’t supported by the primary extraction method.
  - Extraction now reports clearer errors when the fallback command fails.
  - Existing handling for other extraction errors remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->